### PR TITLE
Standardize code formatting

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -242,8 +242,12 @@ if (CONSISTENCY_FAIL)
     set (CONSISTENCY_FAIL_FLAG "-DCONSISTENCY_FAIL")
 endif ()
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++11 -Wall -Wextra -pedantic -Wno-unused-parameter -Winline ${ATLAS_SPECIFIC_FLAGS}")
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -std=c11 -Wall -Wextra -pedantic -Wno-unused-parameter -Winline ${ATLAS_SPECIFIC_FLAGS}")
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -pedantic -Wno-unused-parameter -Winline ${ATLAS_SPECIFIC_FLAGS}")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall -Wextra -pedantic -Wno-unused-parameter -Winline ${ATLAS_SPECIFIC_FLAGS}")
 
 #copy necessary files from the src dir to the build dir
 foreach (t ${ATLAS_COPY_FILES})

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -247,7 +247,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -pedantic -Wno-unused-parameter -Winline ${ATLAS_SPECIFIC_FLAGS}")
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall -Wextra -pedantic -Wno-unused-parameter -Winline ${ATLAS_SPECIFIC_FLAGS}")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall -Wextra -pedantic -Winline ${ATLAS_SPECIFIC_FLAGS}")
 
 #copy necessary files from the src dir to the build dir
 foreach (t ${ATLAS_COPY_FILES})

--- a/runtime/src/internal_includes/internal_api.h
+++ b/runtime/src/internal_includes/internal_api.h
@@ -53,7 +53,7 @@ extern "C" {
 // Read timestamp (x86)
 static inline uint64_t atlas_rdtsc() {
     uint32_t lo, hi;
-    asm volatile ("rdtsc" : "=a" (lo), "=d" (hi));
+    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
     return lo | ((uint64_t)hi << 32);
 }
 

--- a/runtime/tests/consistency/malloc_free_test.c
+++ b/runtime/tests/consistency/malloc_free_test.c
@@ -12,32 +12,38 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
-#include <stdlib.h>
-#include <stdio.h>
 #include "atlas_alloc.h"
 #include "atlas_api.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+
 uint32_t rgn_id;
-int main(){
-    NVM_Initialize();
-    rgn_id = NVM_FindOrCreateRegion("free_test", O_RDWR, NULL);
-    void * rgn_root = NVM_GetRegionRoot(rgn_id);
-    int * testint;
-    if(!rgn_root){
-        testint = nvm_alloc(sizeof(int), rgn_id);
-        *testint = 10;
-        NVM_SetRegionRoot(rgn_id, testint);
-    }else{
-        testint = rgn_root;
-        printf("testint is %i\n", *testint);
-    }
+
+int main() {
+  NVM_Initialize();
+  rgn_id = NVM_FindOrCreateRegion("free_test", O_RDWR, NULL);
+
+  int *testint;
+  void *rgn_root = NVM_GetRegionRoot(rgn_id);
+  if (!rgn_root) {
+    testint = (int *)nvm_alloc(sizeof(int), rgn_id);
+    *testint = 10;
+    NVM_SetRegionRoot(rgn_id, testint);
+  } else {
+    testint = (int *)rgn_root;
+    printf("testint is %i\n", *testint);
+  }
+
 #ifdef CONSISTENCY_FAIL
-    exit(0);
+  exit(0);
 #endif
-    nvm_free(testint);
-    NVM_DeleteRegion("free_test");
-    NVM_Finalize();
-    return 0;
+
+  nvm_free(testint);
+
+  NVM_DeleteRegion("free_test");
+  NVM_Finalize();
+
+  return 0;
 }

--- a/runtime/tests/consistency/malloc_free_test.c
+++ b/runtime/tests/consistency/malloc_free_test.c
@@ -22,28 +22,28 @@
 uint32_t rgn_id;
 
 int main() {
-  NVM_Initialize();
-  rgn_id = NVM_FindOrCreateRegion("free_test", O_RDWR, NULL);
+    NVM_Initialize();
+    rgn_id = NVM_FindOrCreateRegion("free_test", O_RDWR, NULL);
 
-  int *testint;
-  void *rgn_root = NVM_GetRegionRoot(rgn_id);
-  if (!rgn_root) {
-    testint = (int *)nvm_alloc(sizeof(int), rgn_id);
-    *testint = 10;
-    NVM_SetRegionRoot(rgn_id, testint);
-  } else {
-    testint = (int *)rgn_root;
-    printf("testint is %i\n", *testint);
-  }
+    int *testint;
+    void *rgn_root = NVM_GetRegionRoot(rgn_id);
+    if (!rgn_root) {
+        testint = (int *)nvm_alloc(sizeof(int), rgn_id);
+        *testint = 10;
+        NVM_SetRegionRoot(rgn_id, testint);
+    } else {
+        testint = (int *)rgn_root;
+        printf("testint is %i\n", *testint);
+    }
 
 #ifdef CONSISTENCY_FAIL
-  exit(0);
+    exit(0);
 #endif
 
-  nvm_free(testint);
+    nvm_free(testint);
 
-  NVM_DeleteRegion("free_test");
-  NVM_Finalize();
+    NVM_DeleteRegion("free_test");
+    NVM_Finalize();
 
-  return 0;
+    return 0;
 }

--- a/runtime/tests/data_structures/alarm_clock.c
+++ b/runtime/tests/data_structures/alarm_clock.c
@@ -13,7 +13,6 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-
 /*
  * Alarm clock
  * Functionality:
@@ -23,28 +22,28 @@
  * - Search for an alarm and change its parameters
  */
 
+#include <pthread.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <pthread.h>
-#include <inttypes.h>
-#include <assert.h>
 #include <string.h>
 #include <sys/time.h>
 
 #define AC_TABLE_SIZE 32
-#define AC_TABLE_MASK (AC_TABLE_SIZE-1)
-#define AC_TABLE_ENTRY(hour, min) (AlarmClockTab + (((hour)+(min)) & AC_TABLE_MASK))
-#define AC_LOCK(hour, min) (AlarmClockLockTab + (((hour)+(min)) & AC_TABLE_MASK))
+#define AC_TABLE_MASK (AC_TABLE_SIZE - 1)
+#define AC_TABLE_ENTRY(hour, min)                                              \
+    (AlarmClockTab + (((hour) + (min)) & AC_TABLE_MASK))
+#define AC_LOCK(hour, min)                                                     \
+    (AlarmClockLockTab + (((hour) + (min)) & AC_TABLE_MASK))
 
-typedef struct AlarmClockInfo
-{
+typedef struct AlarmClockInfo {
     uint8_t hour;
     uint8_t min;
     uint8_t mode;
     uint8_t repeat_factor;
-    char    name[128];
+    char name[128];
     struct AlarmClockInfo *next;
-}AlarmClockInfo;
+} AlarmClockInfo;
 
 AlarmClockInfo **AlarmClockTab;
 pthread_mutex_t AlarmClockLockTab[AC_TABLE_SIZE];
@@ -55,9 +54,8 @@ int cancelled_alarms = 0;
 int failed_cancel_alarms = 0;
 
 AlarmClockInfo *CreateNewInfo(uint8_t hour, uint8_t min, uint8_t mode,
-                              uint8_t repeat_factor, char *name)
-{
-    AlarmClockInfo *ninfo = (AlarmClockInfo*) malloc(sizeof(AlarmClockInfo));
+                              uint8_t repeat_factor, char *name) {
+    AlarmClockInfo *ninfo = (AlarmClockInfo *)malloc(sizeof(AlarmClockInfo));
     ninfo->hour = hour;
     ninfo->min = min;
     ninfo->mode = mode;
@@ -67,28 +65,23 @@ AlarmClockInfo *CreateNewInfo(uint8_t hour, uint8_t min, uint8_t mode,
     return ninfo;
 }
 
-static inline pthread_mutex_t *GetLock(uint8_t hour, uint8_t min)
-{
+static inline pthread_mutex_t *GetLock(uint8_t hour, uint8_t min) {
     return AC_LOCK(hour, min);
 }
 
-static inline AlarmClockInfo *GetHeader(uint8_t hour, uint8_t min)
-{
+static inline AlarmClockInfo *GetHeader(uint8_t hour, uint8_t min) {
     return *AC_TABLE_ENTRY(hour, min);
 }
 
 int add_or_update_alarm(uint8_t hour, uint8_t min, uint8_t mode,
-                         uint8_t repeat_factor, char *name)
-{
+                        uint8_t repeat_factor, char *name) {
     pthread_mutex_t *bucket_mtx = GetLock(hour, min);
     pthread_mutex_lock(bucket_mtx);
     AlarmClockInfo *header = GetHeader(hour, min);
     AlarmClockInfo *temp = header;
     // Check whether an existing entry should be updated
-    while (temp)
-    {
-        if (temp->hour == hour && temp->min == min)
-        {
+    while (temp) {
+        if (temp->hour == hour && temp->min == min) {
             temp->mode = mode;
             temp->repeat_factor = repeat_factor;
             strcpy(temp->name, name);
@@ -98,31 +91,32 @@ int add_or_update_alarm(uint8_t hour, uint8_t min, uint8_t mode,
         temp = temp->next;
     }
     // A new entry is inserted
-    AlarmClockInfo *naci = CreateNewInfo(hour,min,mode,repeat_factor,name);
+    AlarmClockInfo *naci = CreateNewInfo(hour, min, mode, repeat_factor, name);
     naci->next = header;
-    *AC_TABLE_ENTRY(hour,min) = naci;
+    *AC_TABLE_ENTRY(hour, min) = naci;
     pthread_mutex_unlock(bucket_mtx);
     return 1;
 }
 
 // Return 1 if found and removed, otherwise return 0
-int cancel_alarm(uint8_t hour, uint8_t min, int play)
-{
+int cancel_alarm(uint8_t hour, uint8_t min, int play) {
     pthread_mutex_t *bucket_mtx = GetLock(hour, min);
     pthread_mutex_lock(bucket_mtx);
     AlarmClockInfo *cand = GetHeader(hour, min);
     AlarmClockInfo *prev = NULL;
-    while (cand)
-    {
-        if (cand->hour == hour && cand->min == min)
-        {
+    while (cand) {
+        if (cand->hour == hour && cand->min == min) {
             // Optionally, play the alarm here before essentially removing it
             // ...
 
-            if (play)
+            if (play) {
                 ; // sound an alarm
-            if (!prev) *AC_TABLE_ENTRY(hour, min) = cand->next;
-            else prev->next = cand->next;
+            }
+            if (!prev) {
+                *AC_TABLE_ENTRY(hour, min) = cand->next;
+            } else {
+                prev->next = cand->next;
+            }
             free(cand);
             pthread_mutex_unlock(bucket_mtx);
             return 1;
@@ -134,45 +128,39 @@ int cancel_alarm(uint8_t hour, uint8_t min, int play)
     return 0;
 }
 
-void print_alarms()
-{
-    int i;
+void print_alarms() {
     fprintf(stderr, "---------------\n");
-    for (i=0; i < AC_TABLE_SIZE; ++i)
-    {
+    for (int i = 0; i < AC_TABLE_SIZE; ++i) {
         AlarmClockInfo *aci = AlarmClockTab[i];
-        while (aci)
-        {
-            fprintf(stderr, "%d %d %d %d %s\n",
-                    aci->hour, aci->min, aci->mode, aci->repeat_factor,
-                    aci->name);
+        while (aci) {
+            fprintf(stderr, "%d %d %d %d %s\n", aci->hour, aci->min, aci->mode,
+                    aci->repeat_factor, aci->name);
             aci = aci->next;
         }
     }
 }
 
-void *play_alarms()
-{
+void *play_alarms() {
     int8_t hour = 23;
     int8_t min;
     int status;
-    while (hour >= 0)
-    {
+    while (hour >= 0) {
         min = 59;
-        while (min >= 0)
-        {
+        while (min >= 0) {
             status = cancel_alarm(hour, min, 1);
-            if (status) ++cancelled_alarms;
-            else ++failed_cancel_alarms;
+            if (status) {
+                ++cancelled_alarms;
+            } else {
+                ++failed_cancel_alarms;
+            }
             min -= 1;
         }
-        -- hour;
+        --hour;
     }
     return NULL;
 }
 
-int main()
-{
+int main() {
     struct timeval tv_start;
     struct timeval tv_end;
 
@@ -181,33 +169,34 @@ int main()
     pthread_t th;
 
     AlarmClockTab =
-        (AlarmClockInfo**)malloc(AC_TABLE_SIZE * sizeof(AlarmClockInfo*));
+        (AlarmClockInfo **)malloc(AC_TABLE_SIZE * sizeof(AlarmClockInfo *));
 
-    pthread_create(&th, 0, (void *(*)(void*))play_alarms, 0);
+    pthread_create(&th, 0, (void *(*)(void *))play_alarms, 0);
 
     uint8_t hour = 0;
     uint8_t min;
     int ret;
-    while (hour < 24)
-    {
+    while (hour < 24) {
         min = 0;
-        while (min < 60)
-        {
+        while (min < 60) {
             ret = add_or_update_alarm(hour, min, 0, 0, "");
-            if (ret) ++ set_alarms;
-            else ++ update_alarms;
+            if (ret) {
+                ++set_alarms;
+            } else {
+                ++update_alarms;
+            }
             min += 1;
         }
         hour += 1;
     }
     pthread_join(th, NULL);
-//    print_alarms();
+    // print_alarms();
     fprintf(stderr,
             "Set = %d Updated = %d Cancelled = %d Failed canceling = %d\n",
             set_alarms, update_alarms, cancelled_alarms, failed_cancel_alarms);
     gettimeofday(&tv_end, NULL);
     fprintf(stderr, "time elapsed %ld us\n",
             tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
     return 0;
 }

--- a/runtime/tests/data_structures/alarm_clock.c
+++ b/runtime/tests/data_structures/alarm_clock.c
@@ -54,7 +54,7 @@ int cancelled_alarms = 0;
 int failed_cancel_alarms = 0;
 
 AlarmClockInfo *CreateNewInfo(uint8_t hour, uint8_t min, uint8_t mode,
-                              uint8_t repeat_factor, char *name) {
+                              uint8_t repeat_factor, const char *name) {
     AlarmClockInfo *ninfo = (AlarmClockInfo *)malloc(sizeof(AlarmClockInfo));
     ninfo->hour = hour;
     ninfo->min = min;
@@ -74,7 +74,7 @@ static inline AlarmClockInfo *GetHeader(uint8_t hour, uint8_t min) {
 }
 
 int add_or_update_alarm(uint8_t hour, uint8_t min, uint8_t mode,
-                        uint8_t repeat_factor, char *name) {
+                        uint8_t repeat_factor, const char *name) {
     pthread_mutex_t *bucket_mtx = GetLock(hour, min);
     pthread_mutex_lock(bucket_mtx);
     AlarmClockInfo *header = GetHeader(hour, min);

--- a/runtime/tests/data_structures/cow_array_list_nvm.c
+++ b/runtime/tests/data_structures/cow_array_list_nvm.c
@@ -12,48 +12,43 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <assert.h>
 #include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <sys/time.h>
-#include <inttypes.h>
 
-#include "atlas_api.h" 
 #include "atlas_alloc.h"
+#include "atlas_api.h"
 
 #define INITIAL_SIZE 1000
 #define NUM_ITER 10
 
-typedef struct COW_AL_INTERNAL
-{
+typedef struct COW_AL_INTERNAL {
     int *data;
     int size;
     int version;
-}COW_AL_INTERNAL;
+} COW_AL_INTERNAL;
 
-typedef struct COW_AL
-{
-    COW_AL_INTERNAL * cal_int;
-}COW_AL;
+typedef struct COW_AL {
+    COW_AL_INTERNAL *cal_int;
+} COW_AL;
 
-typedef struct COW_AL_ITER
-{
-    COW_AL_INTERNAL * cal_int;
-}COW_AL_ITER;
+typedef struct COW_AL_ITER {
+    COW_AL_INTERNAL *cal_int;
+} COW_AL_ITER;
 
-COW_AL * create_cal();
-void add_cal(COW_AL * cal, int num);
-void insert_cal(COW_AL * cal, int index, int num);
-int remove_cal(COW_AL * cal, int index);
-int cal_contains(COW_AL * cal, int num);
-int cal_get(COW_AL * cal, int index);
-int size(COW_AL * cal);
-COW_AL_ITER * create_iter(COW_AL *);
-int * iter_first(COW_AL_ITER *);
-int * iter_last(COW_AL_ITER *);
+COW_AL *create_cal();
+void add_cal(COW_AL *cal, int num);
+void insert_cal(COW_AL *cal, int index, int num);
+int remove_cal(COW_AL *cal, int index);
+int cal_contains(COW_AL *cal, int num);
+int cal_get(COW_AL *cal, int index);
+int size(COW_AL *cal);
+COW_AL_ITER *create_iter(COW_AL *);
+int *iter_first(COW_AL_ITER *);
+int *iter_last(COW_AL_ITER *);
 void print_cal(COW_AL *);
 
 pthread_mutex_t lock_cal;
@@ -62,22 +57,20 @@ pthread_mutex_t ready_lock;
 int ready = 0;
 int done = 0;
 
-COW_AL * alist = 0;
+COW_AL *alist = 0;
 
 uint32_t cal_rgn_id;
 
-COW_AL_INTERNAL * GetNewCalInternal()
-{
-    COW_AL_INTERNAL * cal_int =
-        (COW_AL_INTERNAL *) nvm_alloc(sizeof(COW_AL_INTERNAL), cal_rgn_id);
+COW_AL_INTERNAL *GetNewCalInternal() {
+    COW_AL_INTERNAL *cal_int =
+        (COW_AL_INTERNAL *)nvm_alloc(sizeof(COW_AL_INTERNAL), cal_rgn_id);
+    assert(cal_int);
     return cal_int;
 }
 
-int DoAtomicSwitch(COW_AL * cal, COW_AL_INTERNAL * cal_int)
-{
+int DoAtomicSwitch(COW_AL *cal, COW_AL_INTERNAL *cal_int) {
     pthread_mutex_lock(&lock_cal);
-    if (cal->cal_int->version != cal_int->version)
-    {
+    if (cal->cal_int->version != cal_int->version) {
         pthread_mutex_unlock(&lock_cal);
         return 0;
     }
@@ -87,194 +80,175 @@ int DoAtomicSwitch(COW_AL * cal, COW_AL_INTERNAL * cal_int)
     return 1;
 }
 
-COW_AL * create_cal()
-{
-    COW_AL_INTERNAL * cal_int = GetNewCalInternal();
+COW_AL *create_cal() {
+    COW_AL_INTERNAL *cal_int = GetNewCalInternal();
 
-    int * tmp = (int *) nvm_alloc(INITIAL_SIZE * sizeof(int), cal_rgn_id);
+    int *tmp = (int *)nvm_alloc(INITIAL_SIZE * sizeof(int), cal_rgn_id);
+    assert(tmp);
 
-    int i;
-    for (i = 0; i < INITIAL_SIZE; ++i)
-    {
+    for (int i = 0; i < INITIAL_SIZE; ++i) {
         tmp[i] = i;
     }
 
     cal_int->data = tmp;
     cal_int->size = INITIAL_SIZE;
     cal_int->version = 0;
-    
-    COW_AL * cal = (COW_AL *) nvm_alloc(sizeof(COW_AL), cal_rgn_id);
+
+    COW_AL *cal = (COW_AL *)nvm_alloc(sizeof(COW_AL), cal_rgn_id);
+    assert(cal);
     cal->cal_int = cal_int;
 
     return cal;
 }
 
-void add_cal(COW_AL * cal, int num)
-{
+void add_cal(COW_AL *cal, int num) {
     int status = 0;
     int iter = 0;
-    do 
-    {
-        COW_AL_INTERNAL * cal_int = GetNewCalInternal();
+    do {
+        COW_AL_INTERNAL *cal_int = GetNewCalInternal();
         cal_int->version = cal->cal_int->version;
-        cal_int->size = cal->cal_int->size+1;
-        int * tmp = (int *) nvm_alloc(cal_int->size*sizeof(int), cal_rgn_id);
+        cal_int->size = cal->cal_int->size + 1;
+        int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
         assert(tmp);
         cal_int->data = tmp;
-        int i;
-        for (i = 0; i < cal_int->size-1; ++ i)
-        {
+        for (int i = 0; i < cal_int->size - 1; ++i) {
             cal_int->data[i] = cal->cal_int->data[i];
         }
-        cal_int->data[cal_int->size-1] = num;
+        cal_int->data[cal_int->size - 1] = num;
         status = DoAtomicSwitch(cal, cal_int);
         ++iter;
-    }while (!status);
-//    fprintf(stderr, "Added in %d attempts\n", iter);
+    } while (!status);
+    // fprintf(stderr, "Added in %d attempts\n", iter);
 }
 
-void insert_cal(COW_AL * cal, int index, int num)
-{
+void insert_cal(COW_AL *cal, int index, int num) {
     int status = 0;
     int iter = 0;
-    do
-    {
-        COW_AL_INTERNAL * cal_int = GetNewCalInternal();
+    do {
+        COW_AL_INTERNAL *cal_int = GetNewCalInternal();
         cal_int->version = cal->cal_int->version;
-        cal_int->size = cal->cal_int->size+1;
+        cal_int->size = cal->cal_int->size + 1;
         assert(index < cal_int->size);
-        int * tmp = (int *) nvm_alloc(cal_int->size*sizeof(int),
-                                      cal_rgn_id);
+        int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
         assert(tmp);
         cal_int->data = tmp;
         int i;
-        for (i=0; i<index; ++i)
-        {
+        for (i = 0; i < index; ++i) {
             cal_int->data[i] = cal->cal_int->data[i];
         }
         cal_int->data[index] = num;
-        for (i=index+1; i < cal_int->size; ++i)
-        {
-            cal_int->data[i] = cal->cal_int->data[i-1];
+        for (i = index + 1; i < cal_int->size; ++i) {
+            cal_int->data[i] = cal->cal_int->data[i - 1];
         }
         status = DoAtomicSwitch(cal, cal_int);
         ++iter;
-    }while (!status);
-//    fprintf(stderr, "Inserted in %d attempts\n", iter);
+    } while (!status);
+    // fprintf(stderr, "Inserted in %d attempts\n", iter);
 }
 
-int remove_cal(COW_AL * cal, int index)
-{
+int remove_cal(COW_AL *cal, int index) {
     int status = 0;
     int iter = 0;
     int removed_item;
-    do 
-    {
-        COW_AL_INTERNAL * cal_int = GetNewCalInternal();
+    do {
+        COW_AL_INTERNAL *cal_int = GetNewCalInternal();
         assert(index < cal->cal_int->size);
         cal_int->version = cal->cal_int->version;
-        cal_int->size = cal->cal_int->size-1;
-        int *tmp = (int *) nvm_alloc(cal_int->size*sizeof(int), cal_rgn_id);
+        cal_int->size = cal->cal_int->size - 1;
+        int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
+        assert(tmp);
         cal_int->data = tmp;
         int i;
-        for (i=0; i<index; ++i)
-        {
+        for (i = 0; i < index; ++i) {
             cal_int->data[i] = cal->cal_int->data[i];
         }
         removed_item = cal->cal_int->data[index];
-        for (i=index+1; i < cal_int->size+1; ++i)
-        {
-            cal_int->data[i-1] = cal->cal_int->data[i];
+        for (i = index + 1; i < cal_int->size + 1; ++i) {
+            cal_int->data[i - 1] = cal->cal_int->data[i];
         }
         status = DoAtomicSwitch(cal, cal_int);
         ++iter;
-    }while (!status);
-//    fprintf(stderr, "Removed in %d attempts\n", iter);
+    } while (!status);
+    // fprintf(stderr, "Removed in %d attempts\n", iter);
     return removed_item;
 }
-        
-int cal_contains(COW_AL * cal, int num)
-{
-    int * data = cal->cal_int->data;
-    int i;
-    for (i=0; i<cal->cal_int->size; ++i)
-        if (data[i] == num) return 1;
+
+int cal_contains(COW_AL *cal, int num) {
+    int *data = cal->cal_int->data;
+    for (int i = 0; i < cal->cal_int->size; ++i) {
+        if (data[i] == num) {
+            return 1;
+        }
+    }
     return 0;
 }
 
-int cal_get(COW_AL * cal, int index)
-{
+int cal_get(COW_AL *cal, int index) {
     assert(index < cal->cal_int->size);
     return cal->cal_int->data[index];
 }
 
-int size(COW_AL * cal)
-{
+int size(COW_AL *cal) {
     return cal->cal_int->size;
 }
 
-COW_AL_ITER * create_iter(COW_AL * al)
-{
-    COW_AL_ITER * cal_iter = (COW_AL_ITER *) malloc(sizeof(cal_iter));
+COW_AL_ITER *create_iter(COW_AL *al) {
+    COW_AL_ITER *cal_iter = (COW_AL_ITER *)malloc(sizeof(COW_AL_ITER));
     assert(cal_iter);
 
     cal_iter->cal_int = al->cal_int;
     return cal_iter;
 }
 
-int * iter_first(COW_AL_ITER * it)
-{
+int *iter_first(COW_AL_ITER *it) {
     return it->cal_int->data;
 }
 
-int * iter_last(COW_AL_ITER * it)
-{
-    COW_AL_INTERNAL * cal_int = it->cal_int;
+int *iter_last(COW_AL_ITER *it) {
+    COW_AL_INTERNAL *cal_int = it->cal_int;
     return cal_int->data + (cal_int->size - 1);
 }
 
-void print_cal(COW_AL * cal)
-{
-    COW_AL_ITER * alist_iter = create_iter(cal);
-    int * ifirst = iter_first(alist_iter);
-    int * ilast = iter_last(alist_iter);
-    while (ifirst)
-    {
+void print_cal(COW_AL *cal) {
+    COW_AL_ITER *alist_iter = create_iter(cal);
+    int *ifirst = iter_first(alist_iter);
+    int *ilast = iter_last(alist_iter);
+    while (ifirst) {
         fprintf(stderr, "%d ", *ifirst);
-        if (ifirst == ilast) break;
-        ++ ifirst;
+        if (ifirst == ilast) {
+            break;
+        }
+        ++ifirst;
     }
     fprintf(stderr, "\n");
     free(alist_iter);
 }
-    
-uint64_t sum_cal(COW_AL * cal)
-{
+
+uint64_t sum_cal(COW_AL *cal) {
     uint64_t sum = 0;
-    COW_AL_ITER * alist_iter = create_iter(cal);
-    int * ifirst = iter_first(alist_iter);
-    int * ilast = iter_last(alist_iter);
-    while (ifirst)
-    {
+    COW_AL_ITER *alist_iter = create_iter(cal);
+    int *ifirst = iter_first(alist_iter);
+    int *ilast = iter_last(alist_iter);
+    while (ifirst) {
         sum += *ifirst;
-        if (ifirst == ilast) break;
-        ++ ifirst;
+        if (ifirst == ilast) {
+            break;
+        }
+        ++ifirst;
     }
     free(alist_iter);
-//    fprintf(stderr, "%d\n", sum);
+    // fprintf(stderr, "%d\n", sum);
     return sum;
 }
 
-void * do_work()
-{
+void *do_work() {
     pthread_mutex_lock(&ready_lock);
     ready = 1;
     pthread_mutex_unlock(&ready_lock);
 
     uint64_t sum = 0;
     int count = 0;
-    while (count < NUM_ITER)
-    {
+    while (count < NUM_ITER) {
         remove_cal(alist, 85);
         sum += sum_cal(alist);
 
@@ -283,8 +257,9 @@ void * do_work()
         sum += sum_cal(alist);
 
 #ifdef _FORCE_FAIL
-    if (count == NUM_ITER/2) exit(0);
-#endif    
+        if (count == NUM_ITER/2) exit(0);
+#endif
+
         add_cal(alist, 105);
         sum += sum_cal(alist);
 
@@ -294,8 +269,7 @@ void * do_work()
     return 0;
 }
 
-int main()
-{
+int main() {
     struct timeval tv_start;
     struct timeval tv_end;
     pthread_t th;
@@ -304,16 +278,15 @@ int main()
 
     NVM_Initialize();
     cal_rgn_id = NVM_FindOrCreateRegion("cal", O_RDWR, NULL);
-    
+
     alist = create_cal();
-    
+
     NVM_SetRegionRoot(cal_rgn_id, alist);
-    
+
     pthread_create(&th, 0, (void *(*)(void *))do_work, 0);
 
-    int t=0;
-    while (!t)
-    {
+    int t = 0;
+    while (!t) {
         pthread_mutex_lock(&ready_lock);
         t = ready;
         pthread_mutex_unlock(&ready_lock);
@@ -321,8 +294,7 @@ int main()
 
     uint64_t sum = 0;
     int count = 0;
-    while (count < NUM_ITER)
-    {
+    while (count < NUM_ITER) {
         sum += sum_cal(alist);
 
         add_cal(alist, 100);
@@ -332,8 +304,8 @@ int main()
         sum += sum_cal(alist);
 
 #ifdef _FORCE_FAIL
-    if (count == NUM_ITER/2) exit(0);
-#endif    
+        if (count == NUM_ITER/2) exit(0);
+#endif
         remove_cal(alist, 50);
         sum += sum_cal(alist);
 
@@ -353,8 +325,8 @@ int main()
     gettimeofday(&tv_end, NULL);
     fprintf(stderr, "time elapsed %ld us\n",
             tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
-    
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+
     return 0;
 }
 

--- a/runtime/tests/data_structures/queue.c
+++ b/runtime/tests/data_structures/queue.c
@@ -12,33 +12,29 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
 // Adapted from Michael & Scott, "Simple, Fast, and Practical Non-Blocking
 // and Blocking Concurrent Queue Algorithms", PODC 1996.
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <pthread.h>
-#include <sched.h>
 #include <sys/time.h>
 
 #define NUM_ITEMS 100000
 
-typedef struct node_t
-{
+typedef struct node_t {
     int val;
-    struct node_t * next;
-}node_t;
+    struct node_t *next;
+} node_t;
 
-typedef struct queue_t 
-{
-    node_t * head;
-    node_t * tail;
+typedef struct queue_t {
+    node_t *head;
+    node_t *tail;
     pthread_mutex_t *head_lock;
     pthread_mutex_t *tail_lock;
-}queue_t;
+} queue_t;
 
-queue_t * Q;
+queue_t *Q;
 
 int ready = 0;
 int done = 0;
@@ -46,26 +42,23 @@ int done = 0;
 pthread_mutex_t ready_lock;
 pthread_mutex_t done_lock;
 
-void initialize()
-{
-    Q = (queue_t *) malloc(sizeof(queue_t));
-    Q->head = NULL;
-    Q->tail = NULL;
-    Q->head_lock = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+void initialize() {
+    Q = (queue_t *)malloc(sizeof(queue_t));
+    Q->head_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
     pthread_mutex_init(Q->head_lock, NULL);
-    Q->tail_lock = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+    Q->tail_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
     pthread_mutex_init(Q->tail_lock, NULL);
-    
-    node_t * node = (node_t *) malloc(sizeof(node_t));
+
+    node_t *node = (node_t *)malloc(sizeof(node_t));
     node->val = -1; // dummy value
     node->next = NULL;
 
-    Q->head = Q->tail = node;
+    Q->head = node;
+    Q->tail = node;
 }
 
-void enqueue(int val)
-{
-    node_t * node = (node_t *) malloc(sizeof(node_t));
+void enqueue(int val) {
+    node_t *node = (node_t *)malloc(sizeof(node_t));
     node->val = val;
     node->next = NULL;
 
@@ -75,13 +68,11 @@ void enqueue(int val)
     pthread_mutex_unlock(Q->tail_lock);
 }
 
-int dequeue(int * valp)
-{
+int dequeue(int *valp) {
     pthread_mutex_lock(Q->head_lock);
-    node_t * node = Q->head;
-    node_t * new_head = node->next;
-    if (new_head == NULL)
-    {
+    node_t *node = Q->head;
+    node_t *new_head = node->next;
+    if (new_head == NULL) {
         pthread_mutex_unlock(Q->head_lock);
         return 0;
     }
@@ -93,21 +84,22 @@ int dequeue(int * valp)
     return 1;
 }
 
-void * do_work()
-{
+void *do_work() {
     pthread_mutex_lock(&ready_lock);
     ready = 1;
     pthread_mutex_unlock(&ready_lock);
 
     int global_count = 0;
     int t = 0;
-    while (1)
-    {
+    while (1) {
         int val;
         int status = dequeue(&val);
-        if (status) ++ global_count;
-        else if (t) break;
-        
+        if (status) {
+            ++global_count;
+        } else if (t) {
+            break;
+        }
+
         pthread_mutex_lock(&done_lock);
         t = done;
         pthread_mutex_unlock(&done_lock);
@@ -116,44 +108,41 @@ void * do_work()
     return 0;
 }
 
-int main()
-{
+int main() {
     pthread_t thread;
     struct timeval tv_start;
     struct timeval tv_end;
-    
 
     gettimeofday(&tv_start, NULL);
-    
+
     initialize();
 
     pthread_create(&thread, 0, (void *(*)(void *))do_work, 0);
 
     // wait for the child to be ready
     int t = 0;
-    while (!t)
-    {
+    while (!t) {
         pthread_mutex_lock(&ready_lock);
         t = ready;
         pthread_mutex_unlock(&ready_lock);
     }
 
-    int i;
-    for (i = 0; i < NUM_ITEMS; ++i)
+    for (int i = 0; i < NUM_ITEMS; ++i) {
         enqueue(i);
+    }
 
     pthread_mutex_lock(&done_lock);
     done = 1;
     pthread_mutex_unlock(&done_lock);
-    
+
     pthread_join(thread, NULL);
 
     fprintf(stderr, "Total # items enqueued is %d\n", NUM_ITEMS);
-    
+
     gettimeofday(&tv_end, NULL);
     fprintf(stderr, "time elapsed %ld us\n",
             tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
-    
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+
     return 0;
 }

--- a/runtime/tests/data_structures/queue_nvm.c
+++ b/runtime/tests/data_structures/queue_nvm.c
@@ -12,38 +12,34 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
 // Adapted from Michael & Scott, "Simple, Fast, and Practical Non-Blocking
 // and Blocking Concurrent Queue Algorithms", PODC 1996.
+#include <assert.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <pthread.h>
-#include <sched.h>
-#include <assert.h>
 #include <sys/time.h>
 
 #define NUM_ITEMS 100000
 
 // Atlas includes
-#include "atlas_api.h" 
 #include "atlas_alloc.h"
+#include "atlas_api.h"
 
-typedef struct node_t
-{
+typedef struct node_t {
     int val;
-    struct node_t * next;
-}node_t;
+    struct node_t *next;
+} node_t;
 
-typedef struct queue_t 
-{
-    node_t * head;
-    node_t * tail;
-    pthread_mutex_t * head_lock;
-    pthread_mutex_t * tail_lock;
-}queue_t;
+typedef struct queue_t {
+    node_t *head;
+    node_t *tail;
+    pthread_mutex_t *head_lock;
+    pthread_mutex_t *tail_lock;
+} queue_t;
 
-queue_t * Q;
+queue_t *Q;
 
 int ready = 0;
 int done = 0;
@@ -51,36 +47,32 @@ int done = 0;
 pthread_mutex_t ready_lock;
 pthread_mutex_t done_lock;
 
-// Id of Atlas persistent region
+// ID of Atlas persistent region
 uint32_t queue_rgn_id;
 
 void traverse();
 
-void initialize()
-{
+void initialize() {
     void *rgn_root = NVM_GetRegionRoot(queue_rgn_id);
-    if (rgn_root)
-    {
-        Q = (queue_t*)rgn_root;
-        Q->head_lock = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+    if (rgn_root) {
+        Q = (queue_t *)rgn_root;
+        Q->head_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
         pthread_mutex_init(Q->head_lock, NULL);
-        Q->tail_lock = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+        Q->tail_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
         pthread_mutex_init(Q->tail_lock, NULL);
 
         fprintf(stderr, "Found queue at %p\n", (void *)Q);
         traverse();
-    }
-    else
-    {
-        node_t *node = (node_t*)nvm_alloc(sizeof(node_t), queue_rgn_id);
-        node->val=-1;
-        node->next=NULL;
-        Q = (queue_t *) nvm_alloc(sizeof(queue_t), queue_rgn_id);
+    } else {
+        node_t *node = (node_t *)nvm_alloc(sizeof(node_t), queue_rgn_id);
+        node->val = -1; // dummy value
+        node->next = NULL;
+        Q = (queue_t *)nvm_alloc(sizeof(queue_t), queue_rgn_id);
         fprintf(stderr, "Created Q at %p\n", (void *)Q);
 
-        Q->head_lock = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+        Q->head_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
         pthread_mutex_init(Q->head_lock, NULL);
-        Q->tail_lock = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+        Q->tail_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
         pthread_mutex_init(Q->tail_lock, NULL);
 
         NVM_BEGIN_DURABLE();
@@ -96,26 +88,23 @@ void initialize()
 }
 
 // not thread safe
-void traverse()
-{
+void traverse() {
     assert(Q);
     assert(Q->head);
     assert(Q->tail);
 
-    node_t * t = Q->head;
+    node_t *t = Q->head;
     fprintf(stderr, "Contents of existing queue: ");
     int elem_count = 0;
-    while (t)
-    {
-//        fprintf(stderr, "%p %d ", t, t->val);
+    while (t) {
+        // fprintf(stderr, "%p %d ", t, t->val);
         ++elem_count;
         t = t->next;
     }
     fprintf(stderr, "elem_count = %d\n", elem_count);
 }
 
-void enqueue(int val)
-{
+void enqueue(int val) {
     node_t *node = (node_t *)nvm_alloc(sizeof(node_t), queue_rgn_id);
     node->val = val;
     node->next = NULL;
@@ -123,26 +112,24 @@ void enqueue(int val)
     pthread_mutex_lock(Q->tail_lock);
     Q->tail->next = node;
 #ifdef _FORCE_FAIL
-    if (val == NUM_ITEMS/2) exit(0);
+    if (val == NUM_ITEMS / 2) exit(0);
 #endif
     Q->tail = node;
     pthread_mutex_unlock(Q->tail_lock);
 }
 
-int dequeue(int * valp)
-{
+int dequeue(int *valp) {
     pthread_mutex_lock(Q->head_lock);
-    node_t * node = Q->head; 
-    node_t * new_head = node->next;
-    if (new_head == NULL)
-    {
+    node_t *node = Q->head;
+    node_t *new_head = node->next;
+    if (new_head == NULL) {
         pthread_mutex_unlock(Q->head_lock);
         return 0;
     }
     *valp = new_head->val;
 #ifdef _FORCE_FAIL
-    if (*valp == NUM_ITEMS/4) exit(0);
-#endif    
+    if (*valp == NUM_ITEMS / 4) exit(0);
+#endif
     Q->head = new_head;
     pthread_mutex_unlock(Q->head_lock);
 
@@ -150,20 +137,21 @@ int dequeue(int * valp)
     return 1;
 }
 
-void * do_work()
-{
+void *do_work() {
     pthread_mutex_lock(&ready_lock);
     ready = 1;
     pthread_mutex_unlock(&ready_lock);
 
     int global_count = 0;
     int t = 0;
-    while (1)
-    {
+    while (1) {
         int val;
         int status = dequeue(&val);
-        if (status) ++ global_count;
-        else if (t) break;
+        if (status) {
+            ++global_count;
+        } else if (t) {
+            break;
+        }
 
         pthread_mutex_lock(&done_lock);
         t = done;
@@ -173,16 +161,16 @@ void * do_work()
 
 #ifdef NVM_STATS
     NVM_PrintStats();
-#endif    
+#endif
+
     return 0;
 }
 
-int main()
-{
+int main() {
     pthread_t thread;
     struct timeval tv_start;
     struct timeval tv_end;
-    
+
     gettimeofday(&tv_start, NULL);
 
     // Initialize Atlas
@@ -196,16 +184,15 @@ int main()
 
     // wait for the child to be ready
     int t = 0;
-    while (!t)
-    {
+    while (!t) {
         pthread_mutex_lock(&ready_lock);
         t = ready;
         pthread_mutex_unlock(&ready_lock);
     }
 
-    int i;
-    for (i = 0; i < NUM_ITEMS; ++i)
+    for (int i = 0; i < NUM_ITEMS; ++i) {
         enqueue(i);
+    }
 
     pthread_mutex_lock(&done_lock);
     done = 1;
@@ -218,15 +205,16 @@ int main()
     // Optionally print Atlas stats
 #ifdef NVM_STATS
     NVM_PrintStats();
-#endif    
+#endif
     // Atlas bookkeeping
     NVM_Finalize();
 
     fprintf(stderr, "Total # items enqueued is %d\n", NUM_ITEMS);
-    
+
     gettimeofday(&tv_end, NULL);
     fprintf(stderr, "time elapsed %ld us\n",
             tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+
     return 0;
 }

--- a/runtime/tests/data_structures/sll.cpp
+++ b/runtime/tests/data_structures/sll.cpp
@@ -12,68 +12,65 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <alloca.h>
 #include <assert.h>
-#include <string.h>
 #include <complex>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/time.h>
 
-typedef struct Node
-{
+typedef struct Node {
     char *Data;
     struct Node *Next;
-}Node;
+} Node;
 
-typedef struct SearchResult
-{
-    Node* Match;
-    Node* Prev;
-}SearchResult;
+typedef struct SearchResult {
+    Node *Match;
+    Node *Prev;
+} SearchResult;
 
 Node *SLL = NULL;
 Node *InsertAfter = NULL;
 
-Node *createNode(int Num, int NumBlanks, int NumFAI)
-{
-    Node *node = (Node *) malloc(sizeof(Node));
-    int num_digits = log10(Num)+1;
+Node *createNode(int Num, int NumBlanks, __attribute__((unused)) int NumFAI) {
+    Node *node = (Node *)malloc(sizeof(Node));
+    int num_digits = log10(Num) + 1;
     int len = num_digits + NumBlanks;
-    node->Data = (char *) malloc((len+1)*sizeof(char));
-    char *tmp_s = (char *) alloca(
-        (num_digits > NumBlanks ? num_digits+1 : NumBlanks+1)*sizeof(char));
+    node->Data = (char *)malloc((len + 1) * sizeof(char));
+
+    char *tmp_s = (char *)alloca(
+        (num_digits > NumBlanks ? num_digits + 1 : NumBlanks + 1) *
+        sizeof(char));
     sprintf(tmp_s, "%d", Num);
+
     memcpy(node->Data, tmp_s, num_digits);
-    for (int i = 0; i < NumBlanks; ++i) tmp_s[i] = ' ';
+
+    for (int i = 0; i < NumBlanks; ++i) {
+        tmp_s[i] = ' ';
+    }
     memcpy(node->Data + num_digits, tmp_s, NumBlanks);
     node->Data[len] = '\0';
     return node;
 }
 
-Node *insertPass1(int Num, int NumBlanks, int NumFAI) 
-{
+Node *insertPass1(int Num, int NumBlanks, int NumFAI) {
     Node *node = createNode(Num, NumBlanks, NumFAI);
-    
+
     // In pass 1, the new node is the last node in the list
     node->Next = NULL;
-    if (!SLL)
-    {
+    if (!SLL) {
         SLL = node; // write-once
         InsertAfter = node;
-    }
-    else
-    {
+    } else {
         InsertAfter->Next = node;
         InsertAfter = node;
     }
     return node;
 }
 
-Node *insertPass2(int Num, int NumBlanks, int NumFAI)
-{
+Node *insertPass2(int Num, int NumBlanks, int NumFAI) {
     Node *node = createNode(Num, NumBlanks, NumFAI);
 
     node->Next = InsertAfter->Next;
@@ -82,49 +79,51 @@ Node *insertPass2(int Num, int NumBlanks, int NumFAI)
     return node;
 }
 
-long printSLL()
-{
+long printSLL() {
     long sum = 0;
     Node *tnode = SLL;
-    while (tnode)
-    {
-//        fprintf(stderr, "%s ", tnode->Data);
+    while (tnode) {
+        // fprintf(stderr, "%s ", tnode->Data);
         sum += atoi(tnode->Data);
         tnode = tnode->Next;
     }
-//    fprintf(stderr, "\n");
+    // fprintf(stderr, "\n");
     return sum;
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     struct timeval tv_start;
     struct timeval tv_end;
     gettimeofday(&tv_start, NULL);
-    
-    if (argc != 4)
-    {
+
+    if (argc != 4) {
         fprintf(stderr, "usage: a.out numInts numBlanks numFAItems\n");
         exit(0);
     }
+
     int N = atoi(argv[1]);
     int K = atoi(argv[2]);
     int X = atoi(argv[3]);
     fprintf(stderr, "N = %d K = %d X = %d\n", N, K, X);
-    assert(!(N%2) && "N is not even");
+    assert(!(N % 2) && "N is not even");
 
     int i;
-    for (i = 1; i < N/2+1; ++i) insertPass1(i, K, X);
+    for (i = 1; i < N / 2 + 1; ++i) {
+        insertPass1(i, K, X);
+    }
     InsertAfter = SLL;
-    for (i = N/2+1; i < N+1; ++i) insertPass2(i, K, X);
-    
-    gettimeofday(&tv_end, NULL);
+
+    for (i = N / 2 + 1; i < N + 1; ++i) {
+        insertPass2(i, K, X);
+    }
 
     fprintf(stderr, "Sum of elements is %ld\n", printSLL());
-    
+
+    gettimeofday(&tv_end, NULL);
+
     fprintf(stderr, "time elapsed %ld us\n",
             tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
 
     return 0;
 }

--- a/runtime/tests/data_structures/sll_ll.cpp
+++ b/runtime/tests/data_structures/sll_ll.cpp
@@ -12,92 +12,88 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <alloca.h>
 #include <assert.h>
-#include <string.h>
 #include <complex>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/time.h>
 
-#include "atlas_api.h"
 #include "atlas_alloc.h"
+#include "atlas_api.h"
 
-typedef struct Node
-{
+typedef struct Node {
     char *Data;
     struct Node *Next;
-}Node;
+} Node;
 
-typedef struct SearchResult
-{
-    Node* Match;
-    Node* Prev;
-}SearchResult;
-
+typedef struct SearchResult {
+    Node *Match;
+    Node *Prev;
+} SearchResult;
 
 Node *SLL = NULL;
 Node *InsertAfter = NULL;
 
-Node *createSingleNode(int Num, int NumBlanks)
-{
-    Node *node = (Node *) malloc(sizeof(Node));
-    int num_digits = log10(Num)+1;
-    int len = num_digits+NumBlanks;
-    node->Data = (char *) malloc((len+1)*sizeof(char));
-    char *tmp_s = (char *) alloca(
-        (num_digits > NumBlanks ? num_digits+1 : NumBlanks+1)*sizeof(char));
+Node *createSingleNode(int Num, int NumBlanks) {
+    Node *node = (Node *)malloc(sizeof(Node));
+    int num_digits = log10(Num) + 1;
+    int len = num_digits + NumBlanks;
+    node->Data = (char *)malloc((len + 1) * sizeof(char));
+
+    char *tmp_s = (char *)alloca(
+        (num_digits > NumBlanks ? num_digits + 1 : NumBlanks + 1) *
+        sizeof(char));
     sprintf(tmp_s, "%d", Num);
+
     memcpy(node->Data, tmp_s, num_digits);
-    for (int i = 0; i < NumBlanks; ++i) tmp_s[i] = ' ';
+
+    for (int i = 0; i < NumBlanks; ++i) {
+        tmp_s[i] = ' ';
+    }
     memcpy(node->Data + num_digits, tmp_s, NumBlanks);
     node->Data[len] = '\0';
 
     // Atlas low-level data sync interface to make sure the entire
     // node reaches persistent memory
-    NVM_PSYNC(node->Data, len+1);
+    NVM_PSYNC(node->Data, len + 1);
     return node;
 }
 
-Node* copySingleNode(Node* orig){
-     Node *new_node = (Node *) malloc(sizeof(Node));
-     new_node->Data = orig->Data;
+Node *copySingleNode(Node *orig) {
+    Node *new_node = (Node *)malloc(sizeof(Node));
+    new_node->Data = orig->Data;
 
-     // Atlas low-level data sync interface
-     NVM_PSYNC(new_node->Data, 64*1); 
-     return new_node;
+    // Atlas low-level data sync interface
+    NVM_PSYNC(new_node->Data, 64 * 1);
+    return new_node;
 }
 
-void flushNode(Node* node)
-{
+void flushNode(Node *node) {
     // Atlas low-level interface to ensure the dirty cache line
     // reaches persistent memory before proceeding
     NVM_FLUSH(&node->Data);
-    // Filter out same cache line 
+    // Filter out same cache line
     if (isOnDifferentCacheLine(&node->Data, &node->Next))
         NVM_FLUSH(&node->Next);
 }
 
-Node *insertPass1(int Num, int NumBlanks) 
-{
+Node *insertPass1(int Num, int NumBlanks) {
     Node *node = createSingleNode(Num, NumBlanks);
-    
+
     // In pass 1, the new node is the last node in the list
     node->Next = NULL;
 
     flushNode(node);
-    
-    if (!SLL)
-    {
+
+    if (!SLL) {
         SLL = node; // write-once
         // Atlas low-level interface
         NVM_FLUSH(&SLL);
         InsertAfter = node;
-    }
-    else
-    {
+    } else {
         InsertAfter->Next = node;
         // Atlas low-level interface
         NVM_FLUSH(&InsertAfter->Next);
@@ -106,120 +102,107 @@ Node *insertPass1(int Num, int NumBlanks)
     return node;
 }
 
-Node* insertPass2(int Num, int NumBlanks, int NumFAI)
-{
-    Node* start_pos = InsertAfter;
- 
-    //create a single node
-    Node* first_inserted = createSingleNode(Num, NumBlanks);
-    Node* orig = start_pos->Next;
-    Node* copy = NULL;
+Node *insertPass2(int Num, int NumBlanks, int NumFAI) {
+    Node *start_pos = InsertAfter;
 
-    if (NumFAI == 1)
-    {
-    	first_inserted->Next = orig;
+    // create a single node
+    Node *first_inserted = createSingleNode(Num, NumBlanks);
+    Node *orig = start_pos->Next;
+    Node *copy = NULL;
+
+    if (NumFAI == 1) {
+        first_inserted->Next = orig;
         InsertAfter = orig;
-    }
-    else if (orig != NULL)
-    {
+    } else if (orig != NULL) {
         copy = copySingleNode(orig);
         first_inserted->Next = copy;
         orig = orig->Next;
-    }
-    else
-    {
+    } else {
         first_inserted->Next = NULL;
         NumFAI = 0;
-        InsertAfter = first_inserted;        
+        InsertAfter = first_inserted;
     }
 
     flushNode(first_inserted);
 
-    for (int i=1; i < NumFAI; ++i)
-    {
-        Node* inserted = createSingleNode(Num + i, NumBlanks);
+    for (int i = 1; i < NumFAI; ++i) {
+        Node *inserted = createSingleNode(Num + i, NumBlanks);
         copy->Next = inserted;
         flushNode(copy);
-        if (orig == NULL || i == NumFAI - 1)
-        {
+        if (orig == NULL || i == NumFAI - 1) {
             inserted->Next = orig;
             InsertAfter = orig;
-        }
-        else 
-        {
+        } else {
             copy = copySingleNode(orig);
             inserted->Next = copy;
             orig = orig->Next;
         }
         flushNode(inserted);
-        
-        if (InsertAfter == NULL)
-        {
+
+        if (InsertAfter == NULL) {
             InsertAfter = inserted;
             break;
-        } 
+        }
     }
 
     start_pos->Next = first_inserted;
     // Atlas low-level interface
     NVM_FLUSH(&start_pos->Next);
-    
+
     return InsertAfter;
 }
 
-long printSLL()
-{
+long printSLL() {
     long sum = 0;
     Node *tnode = SLL;
-    while (tnode)
-    {
-        //    fprintf(stderr, "%s ", tnode->Data);
+    while (tnode) {
+        // fprintf(stderr, "%s ", tnode->Data);
         sum += atoi(tnode->Data);
         tnode = tnode->Next;
     }
-//    fprintf(stderr, "\n");
+    // fprintf(stderr, "\n");
     return sum;
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     struct timeval tv_start;
     struct timeval tv_end;
     gettimeofday(&tv_start, NULL);
-    
-    if (argc != 4)
-    {
+
+    if (argc != 4) {
         fprintf(stderr, "usage: a.out numInts numBlanks numFAItems\n");
         exit(0);
     }
 
     // Atlas initialization to be able to call low-level interfaces
     NVM_Initialize();
-    
+
     int N = atoi(argv[1]);
     int K = atoi(argv[2]);
     int X = atoi(argv[3]);
     fprintf(stderr, "N = %d K = %d X = %d\n", N, K, X);
-    assert(!(N%2) && "N is not even");
+    assert(!(N % 2) && "N is not even");
 
     int i;
-    for (i = 1; i < N/2+1; ++i) insertPass1(i, K);
+    for (i = 1; i < N / 2 + 1; ++i) {
+        insertPass1(i, K);
+    }
     InsertAfter = SLL;
 
-    for (i=N/2+1; i <= N; i += X){
-	insertPass2(i, K, X);
+    for (i = N / 2 + 1; i <= N; i += X) {
+        insertPass2(i, K, X);
     }
-
-    gettimeofday(&tv_end, NULL);
 
     fprintf(stderr, "Sum of elements is %ld\n", printSLL());
 
+    gettimeofday(&tv_end, NULL);
+
     fprintf(stderr, "time elapsed %ld us\n",
             tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
 
     // Atlas finalization
     NVM_Finalize();
-    
+
     return 0;
 }

--- a/runtime/tests/data_structures/sll_mt.cpp
+++ b/runtime/tests/data_structures/sll_mt.cpp
@@ -12,30 +12,26 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
 // Multithreaded version of sll
-#include <stdio.h>
-#include <stdlib.h>
 #include <alloca.h>
 #include <assert.h>
-#include <string.h>
 #include <complex>
-#include <sys/time.h>
 #include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
 
-typedef struct Node
-{
+typedef struct Node {
     char *Data;
     struct Node *Next;
-}Node;
+} Node;
 
-typedef struct SearchResult
-{
-    Node* Match;
-    Node* Prev;
-}SearchResult;
-
+typedef struct SearchResult {
+    Node *Match;
+    Node *Prev;
+} SearchResult;
 
 Node *SLL = NULL;
 int NumItems = 0;
@@ -45,138 +41,131 @@ pthread_mutex_t InsertPosLock = PTHREAD_MUTEX_INITIALIZER;
 Node *InsertAfter = NULL;
 int InsertValue;
 
-Node *createNode(int Num)
-{
-    Node *node = (Node *) malloc(sizeof(Node));
-    int num_digits = log10(Num)+1;
+Node *createNode(int Num) {
+    Node *node = (Node *)malloc(sizeof(Node));
+    int num_digits = log10(Num) + 1;
     int len = num_digits + NumBlanks;
-    node->Data = (char *) malloc((len+1)*sizeof(char));
-    char *tmp_s = (char *) alloca(
-        (num_digits > NumBlanks ? num_digits+1 : NumBlanks+1)*sizeof(char));
+    node->Data = (char *)malloc((len + 1) * sizeof(char));
+    char *tmp_s = (char *)alloca(
+        (num_digits > NumBlanks ? num_digits + 1 : NumBlanks + 1) *
+        sizeof(char));
 
     sprintf(tmp_s, "%d", Num);
     memcpy(node->Data, tmp_s, num_digits);
     node->Data[num_digits] = '\0';
 
     int i;
-    for (i = 0; i < NumBlanks; ++i) tmp_s[i] = ' ';
+    for (i = 0; i < NumBlanks; ++i) {
+        tmp_s[i] = ' ';
+    }
     memcpy(node->Data + num_digits, tmp_s, NumBlanks);
+
     node->Data[len] = '\0';
     return node;
 }
 
-Node *insertPass1(int Num) 
-{
+Node *insertPass1(int Num) {
     Node *node = createNode(Num);
-    
+
     // In pass 1, the new node is the last node in the list
     node->Next = NULL;
-    if (!SLL)
-    {
+    if (!SLL) {
         SLL = node; // write-once
         InsertAfter = node;
-    }
-    else
-    {
+    } else {
         InsertAfter->Next = node;
         InsertAfter = node;
     }
     return node;
 }
 
-long printSLL()
-{
+long printSLL() {
     long sum = 0;
     Node *tnode = SLL;
-    while (tnode)
-    {
-        //    fprintf(stderr, "%s ", tnode->Data);
+    while (tnode) {
+        // fprintf(stderr, "%s ", tnode->Data);
         sum += atoi(tnode->Data);
         tnode = tnode->Next;
     }
-//    fprintf(stderr, "\n");
+    // fprintf(stderr, "\n");
     return sum;
 }
 
-void* insertPass2(void *threadid)
-{
-    Node* insert_after;
+void *insertPass2(__attribute__((unused)) void *threadid) {
+    Node *insert_after;
     int insert_value;
-    while (true)
-    {
+    while (true) {
         pthread_mutex_lock(&InsertPosLock);
-        
+
         insert_after = InsertAfter;
         insert_value = InsertValue;
-        if (insert_value > NumItems)
-        {
-            pthread_mutex_unlock (&InsertPosLock);
+        if (insert_value > NumItems) {
+            pthread_mutex_unlock(&InsertPosLock);
             pthread_exit(NULL);
-        }    
+        }
         InsertValue += 1;
         assert(InsertAfter);
         InsertAfter = InsertAfter->Next;
 
-        pthread_mutex_unlock (&InsertPosLock);
-        
+        pthread_mutex_unlock(&InsertPosLock);
+
         Node *node = createNode(insert_value);
         node->Next = insert_after->Next;
         insert_after->Next = node;
-        
     }
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     struct timeval tv_start;
     struct timeval tv_end;
     gettimeofday(&tv_start, NULL);
-    
-    if (argc != 5)
-    {
-        fprintf(stderr, "usage: a.out numInts numBlanks numFAItems numThreads\n");
+
+    if (argc != 5) {
+        fprintf(stderr,
+                "usage: a.out numInts numBlanks numFAItems numThreads\n");
         exit(0);
     }
+
     NumItems = atoi(argv[1]);
     NumBlanks = atoi(argv[2]);
     NumFAI = atoi(argv[3]);
     int T = atoi(argv[4]);
-    fprintf(stderr, "N = %d K = %d X = %d T = %d\n", NumItems, NumBlanks, NumFAI, T);
-    assert(!(NumItems%2) && "N is not even");
+    fprintf(stderr, "N = %d K = %d X = %d T = %d\n", NumItems, NumBlanks,
+            NumFAI, T);
+    assert(!(NumItems % 2) && "N is not even");
 
-    int i;
-    for (i = 1; i < NumItems/2+1; ++i) insertPass1(i);
+    for (int i = 1; i < NumItems / 2 + 1; ++i) {
+        insertPass1(i);
+    }
     InsertAfter = SLL;
-    InsertValue = NumItems/2+1;
-    
-    long j; 
-    
+    InsertValue = NumItems / 2 + 1;
+
+    long j;
+
     pthread_t *insert_threads = new pthread_t[T];
     int rc;
 
-    for (j=0; j < T; j++)
-    {
-        rc = pthread_create(&insert_threads[j], NULL, insertPass2, (void *) j);
-        if (rc){
-            printf("ERROR; return code from pthread_create() is %d\n", rc);
+    for (j = 0; j < T; j++) {
+        rc = pthread_create(&insert_threads[j], NULL, insertPass2, (void *)j);
+        if (rc) {
+            printf("ERROR: return code from pthread_create() is %d\n", rc);
             exit(-1);
         }
     }
 
-    for (j=0; j < T; j++)
-    {
+    for (j = 0; j < T; j++) {
         pthread_join(insert_threads[j], NULL);
     }
 
-    delete [] insert_threads;
-   
+    delete[] insert_threads;
+
     gettimeofday(&tv_end, NULL);
-     
+
     fprintf(stderr, "Sum of elements is %ld\n", printSLL());
 
     fprintf(stderr, "time elapsed %ld us\n",
             tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
-    
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+
     return 0;
 }

--- a/runtime/tests/data_structures/sll_mt_ll.cpp
+++ b/runtime/tests/data_structures/sll_mt_ll.cpp
@@ -12,32 +12,29 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
-#include <stdio.h>
-#include <stdlib.h>
+// Multithreaded version of sll
 #include <alloca.h>
 #include <assert.h>
-#include <string.h>
 #include <complex>
-#include <sys/time.h>
 #include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
 
-#include "atlas_api.h"
 #include "atlas_alloc.h"
+#include "atlas_api.h"
 
-typedef struct Node
-{
+typedef struct Node {
     char *Data;
     struct Node *Next;
-}Node;
+} Node;
 
-typedef struct SearchResult
-{
-    Node* Match;
-    Node* Prev;
-}SearchResult;
-
+typedef struct SearchResult {
+    Node *Match;
+    Node *Prev;
+} SearchResult;
 
 Node *SLL = NULL;
 int NumItems = 0;
@@ -47,55 +44,44 @@ pthread_mutex_t InsertPosLock = PTHREAD_MUTEX_INITIALIZER;
 Node *InsertAfter = NULL;
 int InsertValue;
 
-//pthread_mutex_t DeletePosLock = PTHREAD_MUTEX_INITIALIZER;
-//int DeleteValue;
-
-//pthread_mutex_t DeleteStartLock = PTHREAD_MUTEX_INITIALIZER;
-//pthread_cond_t DeleteCondVar = PTHREAD_COND_INITIALIZER;
-//bool StartDelete = false;
-
-//int NumRegions = 0;
-//pthread_mutex_t** RegionLocks;
-
-Node *createSingleNode(int Num)
-{
-    Node *node = (Node *) malloc(sizeof(Node));
-    int num_digits = log10(Num)+1;
-    int len = num_digits+NumBlanks;
-    node->Data = (char *) malloc((len+1)*sizeof(char));
-    char *tmp_s = (char *) alloca(
-        (num_digits > NumBlanks ? num_digits+1 : NumBlanks+1)*sizeof(char));
+Node *createSingleNode(int Num) {
+    Node *node = (Node *)malloc(sizeof(Node));
+    int num_digits = log10(Num) + 1;
+    int len = num_digits + NumBlanks;
+    node->Data = (char *)malloc((len + 1) * sizeof(char));
+    char *tmp_s = (char *)alloca(
+        (num_digits > NumBlanks ? num_digits + 1 : NumBlanks + 1) *
+        sizeof(char));
 
     sprintf(tmp_s, "%d", Num);
     memcpy(node->Data, tmp_s, num_digits);
     node->Data[num_digits] = '\0';
 
-    //tmp_s[0] = '\0';
     int i;
-    for (i = 0; i < NumBlanks; ++i) tmp_s[i] = ' ';
+    for (i = 0; i < NumBlanks; ++i) {
+        tmp_s[i] = ' ';
+    }
     memcpy(node->Data + num_digits, tmp_s, NumBlanks);
 
     node->Data[len] = '\0';
-    NVM_PSYNC(node->Data, len+1);
+    NVM_PSYNC(node->Data, len + 1);
     return node;
 }
 
-Node* copySingleNode(Node* orig){
-     Node *new_node = (Node *) malloc(sizeof(Node));
-     new_node->Data = orig->Data;
-     NVM_PSYNC(new_node->Data, 64*5);
-     return new_node;
+Node *copySingleNode(Node *orig) {
+    Node *new_node = (Node *)malloc(sizeof(Node));
+    new_node->Data = orig->Data;
+    NVM_PSYNC(new_node->Data, 64 * 5);
+    return new_node;
 }
 
-void flushNode(Node* node)
-{
+void flushNode(Node *node) {
     NVM_FLUSH(&node->Data);
     if (isOnDifferentCacheLine(&node->Data, &node->Next))
         NVM_FLUSH(&node->Next);
 }
 
-Node *insertPass1(int Num)
-{
+Node *insertPass1(int Num) {
     Node *node = createSingleNode(Num);
 
     // In pass 1, the new node is the last node in the list
@@ -103,14 +89,11 @@ Node *insertPass1(int Num)
 
     flushNode(node);
 
-    if (!SLL)
-    {
+    if (!SLL) {
         SLL = node; // write-once
         NVM_FLUSH(&SLL);
         InsertAfter = node;
-    }
-    else
-    {
+    } else {
         InsertAfter->Next = node;
         NVM_FLUSH(&InsertAfter->Next);
         InsertAfter = node;
@@ -118,144 +101,134 @@ Node *insertPass1(int Num)
     return node;
 }
 
-long printSLL()
-{
+long printSLL() {
     long sum = 0;
     Node *tnode = SLL;
-    while (tnode)
-    {
-        //    fprintf(stderr, "%s ", tnode->Data);
+    while (tnode) {
+        // fprintf(stderr, "%s ", tnode->Data);
         sum += atoi(tnode->Data);
         tnode = tnode->Next;
     }
-//    fprintf(stderr, "\n");
+    // fprintf(stderr, "\n");
     return sum;
 }
 
-void* insertPass2(void *threadid)
-{
-    Node* insert_after;
+void *insertPass2(__attribute__((unused)) void *threadid) {
+    Node *insert_after;
     int insert_value;
-    while (true)
-    {
+    while (true) {
         pthread_mutex_lock(&InsertPosLock);
-        
+
         insert_after = InsertAfter;
         insert_value = InsertValue;
-        if (insert_value > NumItems)
-        {
-            pthread_mutex_unlock (&InsertPosLock);
+        if (insert_value > NumItems) {
+            pthread_mutex_unlock(&InsertPosLock);
             pthread_exit(NULL);
-        }    
+        }
         InsertValue += NumFAI;
         assert(InsertAfter);
-        for (int i=0; i < NumFAI && InsertAfter != NULL; ++i)
+        for (int i = 0; i < NumFAI && InsertAfter != NULL; ++i) {
             InsertAfter = InsertAfter->Next;
-
-        pthread_mutex_unlock (&InsertPosLock);
-
-        Node* start_pos = insert_after;
-
-        Node* first_inserted = createSingleNode(insert_value);
-        Node* orig = start_pos->Next;
-        Node* copy = NULL;
-        int num_fai = NumFAI;
-        if (num_fai == 1)
-            first_inserted->Next = orig;
-        else if (orig != NULL)
-	{
-            copy = copySingleNode(orig); 
-            first_inserted->Next = copy;
-            orig = orig->Next; 
         }
-        else
-        {
+
+        pthread_mutex_unlock(&InsertPosLock);
+
+        Node *start_pos = insert_after;
+
+        Node *first_inserted = createSingleNode(insert_value);
+        Node *orig = start_pos->Next;
+        Node *copy = NULL;
+        int num_fai = NumFAI;
+        if (num_fai == 1) {
+            first_inserted->Next = orig;
+        } else if (orig != NULL) {
+            copy = copySingleNode(orig);
+            first_inserted->Next = copy;
+            orig = orig->Next;
+        } else {
             first_inserted->Next = NULL;
             num_fai = 0;
         }
 
         flushNode(first_inserted);
 
-        for (int i=1; i < num_fai; i++)
-        {
-            Node* inserted = createSingleNode(insert_value + i);
+        for (int i = 1; i < num_fai; i++) {
+            Node *inserted = createSingleNode(insert_value + i);
             copy->Next = inserted;
             flushNode(copy);
-            if (orig == NULL || i == num_fai - 1)
-            {
+            if (orig == NULL || i == num_fai - 1) {
                 inserted->Next = orig;
                 insert_after = orig;
-            }
-            else
-            {
+            } else {
                 copy = copySingleNode(orig);
                 inserted->Next = copy;
                 orig = orig->Next;
             }
             flushNode(inserted);
-            if(insert_after == NULL) break;
-        }        
+            if (insert_after == NULL) {
+                break;
+            }
+        }
         start_pos->Next = first_inserted;
         NVM_FLUSH(&start_pos->Next);
     }
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     struct timeval tv_start;
     struct timeval tv_end;
     gettimeofday(&tv_start, NULL);
-    
-    if (argc != 5)
-    {
-        fprintf(stderr, "usage: a.out numInts numBlanks numFAItems numThreads\n");
+
+    if (argc != 5) {
+        fprintf(stderr,
+                "usage: a.out numInts numBlanks numFAItems numThreads\n");
         exit(0);
     }
 
     NVM_Initialize();
-    
+
     NumItems = atoi(argv[1]);
     NumBlanks = atoi(argv[2]);
     NumFAI = atoi(argv[3]);
     int T = atoi(argv[4]);
-    fprintf(stderr, "N = %d K = %d X = %d T = %d\n", NumItems, NumBlanks, NumFAI, T);
-    assert(!(NumItems%2) && "N is not even");
+    fprintf(stderr, "N = %d K = %d X = %d T = %d\n", NumItems, NumBlanks,
+            NumFAI, T);
+    assert(!(NumItems % 2) && "N is not even");
 
-    int i;
-    for (i = 1; i < NumItems/2+1; ++i) insertPass1(i);
+    for (int i = 1; i < NumItems / 2 + 1; ++i) {
+        insertPass1(i);
+    }
     InsertAfter = SLL;
-    InsertValue = NumItems/2+1;
-    
-    long j; 
-    
+    InsertValue = NumItems / 2 + 1;
+
+    long j;
+
     pthread_t *insert_threads = new pthread_t[T];
     int rc;
 
-    for (j=0; j < T; j++)
-    {
-        rc = pthread_create(&insert_threads[j], NULL, insertPass2, (void *) j);
-        if (rc){
-            printf("ERROR; return code from pthread_create() is %d\n", rc);
+    for (j = 0; j < T; j++) {
+        rc = pthread_create(&insert_threads[j], NULL, insertPass2, (void *)j);
+        if (rc) {
+            printf("ERROR: return code from pthread_create() is %d\n", rc);
             exit(-1);
         }
     }
 
-    for (j=0; j < T; j++)
-    {
+    for (j = 0; j < T; j++) {
         pthread_join(insert_threads[j], NULL);
     }
 
-    delete [] insert_threads;
-   
+    delete[] insert_threads;
+
     gettimeofday(&tv_end, NULL);
-     
+
     fprintf(stderr, "Sum of elements is %ld\n", printSLL());
 
     fprintf(stderr, "time elapsed %ld us\n",
             tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
 
     NVM_Finalize();
-    
+
     return 0;
 }

--- a/runtime/tests/data_structures/sll_nvm.cpp
+++ b/runtime/tests/data_structures/sll_nvm.cpp
@@ -12,33 +12,29 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
 // Compile example: g++ sll.c
-#include <stdio.h>
-#include <stdlib.h>
 #include <alloca.h>
 #include <assert.h>
-#include <string.h>
 #include <complex>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/time.h>
 
 // Atlas includes
-#include "atlas_api.h"
 #include "atlas_alloc.h"
+#include "atlas_api.h"
 
-typedef struct Node
-{
+typedef struct Node {
     char *Data;
     struct Node *Next;
-}Node;
+} Node;
 
-typedef struct SearchResult
-{
-    Node* Match;
-    Node* Prev;
-}SearchResult;
-
+typedef struct SearchResult {
+    Node *Match;
+    Node *Prev;
+} SearchResult;
 
 Node *SLL = NULL;
 Node *InsertAfter = NULL;
@@ -47,132 +43,123 @@ Node *InsertAfter = NULL;
 int randval;
 #endif
 
-// Id of Atlas persistent region
+// ID of Atlas persistent region
 uint32_t sll_rgn_id;
 
-Node *createSingleNode(int Num, int NumBlanks)
-{
-    Node *node = (Node *) nvm_alloc(sizeof(Node), sll_rgn_id);
-    int num_digits = log10(Num)+1;
-    int len = num_digits+NumBlanks;
-    char* d = (char*) nvm_alloc((len+1)*sizeof(char), sll_rgn_id);
+Node *createSingleNode(int Num, int NumBlanks) {
+    Node *node = (Node *)nvm_alloc(sizeof(Node), sll_rgn_id);
+    int num_digits = log10(Num) + 1;
+    int len = num_digits + NumBlanks;
+    char *d = (char *)nvm_alloc((len + 1) * sizeof(char), sll_rgn_id);
     node->Data = d;
 
-    char *tmp_s = (char *) alloca(
-        (num_digits > NumBlanks ? num_digits+1 : NumBlanks+1)*sizeof(char));
+    char *tmp_s = (char *)alloca(
+        (num_digits > NumBlanks ? num_digits + 1 : NumBlanks + 1) *
+        sizeof(char));
     sprintf(tmp_s, "%d", Num);
 
     memcpy(node->Data, tmp_s, num_digits);
 
-    for (int i = 0; i < NumBlanks; ++i) tmp_s[i] = ' ';
-    memcpy(node->Data+num_digits, tmp_s, NumBlanks);
-    node->Data[num_digits+NumBlanks] = '\0';
+    for (int i = 0; i < NumBlanks; ++i) {
+        tmp_s[i] = ' ';
+    }
+    memcpy(node->Data + num_digits, tmp_s, NumBlanks);
+    node->Data[num_digits + NumBlanks] = '\0';
     return node;
 }
 
-Node *insertPass1(int Num, int NumBlanks, int NumFAI) 
-{
+Node *insertPass1(int Num, int NumBlanks, __attribute__((unused)) int NumFAI) {
     Node *node = createSingleNode(Num, NumBlanks);
-    
+
     // In pass 1, the new node is the last node in the list
     node->Next = NULL;
 
     NVM_BEGIN_DURABLE();
 
 #ifdef _FORCE_FAIL
-    if (Num == randval){
-//        printf ("num exiting is %i\n", Num);
+    if (Num == randval) {
+        // printf ("num exiting is %i\n", Num);
         exit(0);
     }
 #endif
-    
-    if (!SLL)
-    {
-        SLL = node;
+
+    if (!SLL) {
+        SLL = node; // write-once
         InsertAfter = node;
-    }
-    else
-    {
+    } else {
         InsertAfter->Next = node;
         InsertAfter = node;
     }
     NVM_END_DURABLE();
-    
+
     return node;
 }
 
-Node *insertPass2(int Num, int NumBlanks, int NumFAI)
-{
-    Node** new_nodes = (Node**) malloc (NumFAI*sizeof(Node*));
-    Node* list_iter = InsertAfter->Next;
-    for (int i=0; i < NumFAI; i++)
-    {
+Node *insertPass2(int Num, int NumBlanks, int NumFAI) {
+    Node **new_nodes = (Node **)malloc(NumFAI * sizeof(Node *));
+    Node *list_iter = InsertAfter->Next;
+    for (int i = 0; i < NumFAI; i++) {
 #ifdef _FORCE_FAIL
-    if (Num == randval){
-//        printf ("num exiting is %i\n", Num);
-        exit(0);
-    }
+        if (Num == randval) {
+            // printf ("num exiting is %i\n", Num);
+            exit(0);
+        }
 #endif
         new_nodes[i] = createSingleNode(Num + i, NumBlanks);
-        if (list_iter != NULL)
-        {
+        if (list_iter != NULL) {
             new_nodes[i]->Next = list_iter;
-        }
-        else
+        } else {
             break;
+        }
         list_iter = list_iter->Next;
     }
 
     // Atlas failure-atomic region
     NVM_BEGIN_DURABLE();
-    
-    for (int i=0; i < NumFAI; i++)
-    {
+
+    for (int i = 0; i < NumFAI; i++) {
         InsertAfter->Next = new_nodes[i];
-        if (new_nodes[i]->Next != NULL)
-             InsertAfter = new_nodes[i]->Next;
-        else 
-        {
-             InsertAfter = new_nodes[i];
-             break;
+        if (new_nodes[i]->Next != NULL) {
+            InsertAfter = new_nodes[i]->Next;
+        } else {
+            InsertAfter = new_nodes[i];
+            break;
         }
     }
-    
+
     NVM_END_DURABLE();
 
     return InsertAfter;
 }
 
-long printSLL()
-{
+long printSLL() {
     long sum = 0;
     Node *tnode = SLL;
-    while (tnode)
-    {
-//        fprintf(stderr, "%s ", tnode->Data);
+    while (tnode) {
+        // fprintf(stderr, "%s ", tnode->Data);
         sum += atoi(tnode->Data);
         tnode = tnode->Next;
     }
-//    fprintf(stderr, "\n");
+    // fprintf(stderr, "\n");
     return sum;
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     struct timeval tv_start;
     struct timeval tv_end;
     gettimeofday(&tv_start, NULL);
-    
-    if (argc != 4)
-    {
+
+    if (argc != 4) {
         fprintf(stderr, "usage: a.out numInts numBlanks numFAItems\n");
         exit(0);
     }
+
     int N = atoi(argv[1]);
     int K = atoi(argv[2]);
     int X = atoi(argv[3]);
     fprintf(stderr, "N = %d K = %d X = %d\n", N, K, X);
-    assert(!(N%2) && "N is not even");
+    assert(!(N % 2) && "N is not even");
+
     assert(X > 0);
 #ifdef _FORCE_FAIL
     srand(time(NULL));
@@ -183,14 +170,18 @@ int main(int argc, char *argv[])
     NVM_Initialize();
     // Create an Atlas persistent region
     sll_rgn_id = NVM_FindOrCreateRegion("sll_ll", O_RDWR, NULL);
-    
+
     int i;
-    for (i = 1; i < N/2+1; ++i) insertPass1(i, K, X);
+    for (i = 1; i < N / 2 + 1; ++i) {
+        insertPass1(i, K, X);
+    }
     InsertAfter = SLL;
 
-    for (i=N/2+1; i < N; i += X) insertPass2(i, K, X);
+    for (i = N / 2 + 1; i < N; i += X) {
+        insertPass2(i, K, X);
+    }
     int total_inserted = i - 1;
-    insertPass2(i, K,  N - total_inserted);
+    insertPass2(i, K, N - total_inserted);
 
     fprintf(stderr, "Sum of elements is %ld\n", printSLL());
 
@@ -207,6 +198,7 @@ int main(int argc, char *argv[])
 
     fprintf(stderr, "time elapsed %ld us\n",
             tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+
     return 0;
 }

--- a/runtime/tests/data_structures/stores.c
+++ b/runtime/tests/data_structures/stores.c
@@ -13,48 +13,48 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-
+#include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <sys/time.h>
-#include <inttypes.h>
 
 #define LOOP_COUNT 1000000
 
 static inline uint64_t rdtsc() {
     uint32_t lo, hi;
-    __asm__ volatile ("rdtsc" : "=a" (lo), "=d" (hi));
+    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
     return lo | ((uint64_t)hi << 32);
 }
 
-int main()
-{
+int main() {
     int *arr;
     int count = 0;
     struct timeval tv_start;
     struct timeval tv_end;
 
-    arr = (int*)malloc(LOOP_COUNT*sizeof(int));
+    arr = (int *)malloc(LOOP_COUNT * sizeof(int));
 
     assert(!gettimeofday(&tv_start, NULL));
 
     uint64_t start = rdtsc();
 
     int i;
-    for (i=0; i<LOOP_COUNT; ++i)
+    for (i = 0; i < LOOP_COUNT; ++i) {
         arr[i] = i;
+    }
 
     uint64_t end = rdtsc();
 
     assert(!gettimeofday(&tv_end, NULL));
 
-    for (i=0; i<LOOP_COUNT; ++i)
+    for (i = 0; i < LOOP_COUNT; ++i) {
         count += arr[i];
+    }
     fprintf(stderr, "Sum of elements is %d\n", count);
     fprintf(stderr, "time elapsed %ld us\n",
             tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
     fprintf(stderr, "cycles: %ld\n", end - start);
 
     return 0;

--- a/runtime/tests/data_structures_instrumented/cow_array_list_nvm.c
+++ b/runtime/tests/data_structures_instrumented/cow_array_list_nvm.c
@@ -37,9 +37,9 @@
 #define NUM_ITER 10
 
 typedef struct COW_AL_INTERNAL {
-  int *data;
-  int size;
-  int version;
+    int *data;
+    int size;
+    int version;
 } COW_AL_INTERNAL;
 
 typedef struct COW_AL { COW_AL_INTERNAL *cal_int; } COW_AL;
@@ -69,287 +69,290 @@ COW_AL *alist = 0;
 uint32_t cal_rgn_id;
 
 COW_AL_INTERNAL *GetNewCalInternal() {
-  COW_AL_INTERNAL *cal_int =
-      (COW_AL_INTERNAL *)nvm_alloc(sizeof(COW_AL_INTERNAL), cal_rgn_id);
-  assert(cal_int);
-  return cal_int;
+    COW_AL_INTERNAL *cal_int =
+        (COW_AL_INTERNAL *)nvm_alloc(sizeof(COW_AL_INTERNAL), cal_rgn_id);
+    assert(cal_int);
+    return cal_int;
 }
 
 int DoAtomicSwitch(COW_AL *cal, COW_AL_INTERNAL *cal_int) {
-  NVM_LOCK(lock_cal);
-  if (cal->cal_int->version != cal_int->version) {
+    NVM_LOCK(lock_cal);
+    if (cal->cal_int->version != cal_int->version) {
+        NVM_UNLOCK(lock_cal);
+        return 0;
+    }
+    NVM_STR2(cal_int->version, cal_int->version + 1,
+             sizeof(cal_int->version) * 8);
+    NVM_STR2(cal->cal_int, cal_int, sizeof(cal->cal_int) * 8);
     NVM_UNLOCK(lock_cal);
-    return 0;
-  }
-  NVM_STR2(cal_int->version, cal_int->version + 1,
-           sizeof(cal_int->version) * 8);
-  NVM_STR2(cal->cal_int, cal_int, sizeof(cal->cal_int) * 8);
-  NVM_UNLOCK(lock_cal);
-  return 1;
+    return 1;
 }
 
 COW_AL *create_cal() {
-  COW_AL_INTERNAL *cal_int = GetNewCalInternal();
+    COW_AL_INTERNAL *cal_int = GetNewCalInternal();
 
-  int *tmp = (int *)nvm_alloc(INITIAL_SIZE * sizeof(int), cal_rgn_id);
-  assert(tmp);
-  int i;
-  for (i = 0; i < INITIAL_SIZE; ++i) {
-    NVM_STR2(tmp[i], i, sizeof(tmp[i]) * 8);
-  }
+    int *tmp = (int *)nvm_alloc(INITIAL_SIZE * sizeof(int), cal_rgn_id);
+    assert(tmp);
+    int i;
+    for (i = 0; i < INITIAL_SIZE; ++i) {
+        NVM_STR2(tmp[i], i, sizeof(tmp[i]) * 8);
+    }
 
-  NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
-  NVM_STR2(cal_int->size, INITIAL_SIZE, sizeof(cal_int->size) * 8);
-  NVM_STR2(cal_int->version, 0, sizeof(cal_int->version) * 8);
+    NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
+    NVM_STR2(cal_int->size, INITIAL_SIZE, sizeof(cal_int->size) * 8);
+    NVM_STR2(cal_int->version, 0, sizeof(cal_int->version) * 8);
 
-  COW_AL *cal = (COW_AL *)nvm_alloc(sizeof(COW_AL), cal_rgn_id);
-  assert(cal);
-  NVM_STR2(cal->cal_int, cal_int, sizeof(cal->cal_int) * 8);
+    COW_AL *cal = (COW_AL *)nvm_alloc(sizeof(COW_AL), cal_rgn_id);
+    assert(cal);
+    NVM_STR2(cal->cal_int, cal_int, sizeof(cal->cal_int) * 8);
 
-  return cal;
+    return cal;
 }
 
 void add_cal(COW_AL *cal, int num) {
-  int status = 0;
-  int iter = 0;
-  do {
-    COW_AL_INTERNAL *cal_int = GetNewCalInternal();
-    NVM_STR2(cal_int->version, cal->cal_int->version,
-             sizeof(cal_int->version) * 8);
-    NVM_STR2(cal_int->size, cal->cal_int->size + 1, sizeof(cal_int->size) * 8);
-    int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
-    assert(tmp);
-    NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
-    int i;
-    for (i = 0; i < cal_int->size - 1; ++i) {
-      NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
-               sizeof(cal_int->data[i]) * 8);
-    }
-    NVM_STR2(cal_int->data[cal_int->size - 1], num,
-             sizeof(cal_int->data[cal_int->size - 1]) * 8);
-    status = DoAtomicSwitch(cal, cal_int);
-    ++iter;
-  } while (!status);
-  //    fprintf(stderr, "Added in %d attempts\n", iter);
+    int status = 0;
+    int iter = 0;
+    do {
+        COW_AL_INTERNAL *cal_int = GetNewCalInternal();
+        NVM_STR2(cal_int->version, cal->cal_int->version,
+                 sizeof(cal_int->version) * 8);
+        NVM_STR2(cal_int->size, cal->cal_int->size + 1,
+                 sizeof(cal_int->size) * 8);
+        int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
+        assert(tmp);
+        NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
+        int i;
+        for (i = 0; i < cal_int->size - 1; ++i) {
+            NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
+                     sizeof(cal_int->data[i]) * 8);
+        }
+        NVM_STR2(cal_int->data[cal_int->size - 1], num,
+                 sizeof(cal_int->data[cal_int->size - 1]) * 8);
+        status = DoAtomicSwitch(cal, cal_int);
+        ++iter;
+    } while (!status);
+    //    fprintf(stderr, "Added in %d attempts\n", iter);
 }
 
 void insert_cal(COW_AL *cal, int index, int num) {
-  int status = 0;
-  int iter = 0;
-  do {
-    COW_AL_INTERNAL *cal_int = GetNewCalInternal();
-    NVM_STR2(cal_int->version, cal->cal_int->version,
-             sizeof(cal_int->version) * 8);
-    NVM_STR2(cal_int->size, cal->cal_int->size + 1, sizeof(cal_int->size) * 8);
-    assert(index < cal_int->size);
-    int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
-    assert(tmp);
-    NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
-    int i;
-    for (i = 0; i < index; ++i) {
-      NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
-               sizeof(cal_int->data[i]) * 8);
-    }
-    NVM_STR2(cal_int->data[index], num, sizeof(cal_int->data[index]) * 8);
-    for (i = index + 1; i < cal_int->size; ++i) {
-      NVM_STR2(cal_int->data[i], cal->cal_int->data[i - 1],
-               sizeof(cal_int->data[i]) * 8);
-    }
-    status = DoAtomicSwitch(cal, cal_int);
-    ++iter;
-  } while (!status);
-  //    fprintf(stderr, "Inserted in %d attempts\n", iter);
+    int status = 0;
+    int iter = 0;
+    do {
+        COW_AL_INTERNAL *cal_int = GetNewCalInternal();
+        NVM_STR2(cal_int->version, cal->cal_int->version,
+                 sizeof(cal_int->version) * 8);
+        NVM_STR2(cal_int->size, cal->cal_int->size + 1,
+                 sizeof(cal_int->size) * 8);
+        assert(index < cal_int->size);
+        int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
+        assert(tmp);
+        NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
+        int i;
+        for (i = 0; i < index; ++i) {
+            NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
+                     sizeof(cal_int->data[i]) * 8);
+        }
+        NVM_STR2(cal_int->data[index], num, sizeof(cal_int->data[index]) * 8);
+        for (i = index + 1; i < cal_int->size; ++i) {
+            NVM_STR2(cal_int->data[i], cal->cal_int->data[i - 1],
+                     sizeof(cal_int->data[i]) * 8);
+        }
+        status = DoAtomicSwitch(cal, cal_int);
+        ++iter;
+    } while (!status);
+    //    fprintf(stderr, "Inserted in %d attempts\n", iter);
 }
 
 int remove_cal(COW_AL *cal, int index) {
-  int status = 0;
-  int iter = 0;
-  int removed_item;
-  do {
-    COW_AL_INTERNAL *cal_int = GetNewCalInternal();
-    assert(index < cal->cal_int->size);
-    NVM_STR2(cal_int->version, cal->cal_int->version,
-             sizeof(cal_int->version) * 8);
-    NVM_STR2(cal_int->size, cal->cal_int->size - 1, sizeof(cal_int->size) * 8);
-    int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
-    assert(tmp);
-    NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
-    int i;
-    for (i = 0; i < index; ++i) {
-      NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
-               sizeof(cal_int->data[i]) * 8);
-    }
-    removed_item = cal->cal_int->data[index];
-    for (i = index + 1; i < cal_int->size + 1; ++i) {
-      NVM_STR2(cal_int->data[i - 1], cal->cal_int->data[i],
-               sizeof(cal_int->data[i - 1]) * 8);
-    }
-    status = DoAtomicSwitch(cal, cal_int);
-    ++iter;
-  } while (!status);
-  //    fprintf(stderr, "Removed in %d attempts\n", iter);
-  return removed_item;
+    int status = 0;
+    int iter = 0;
+    int removed_item;
+    do {
+        COW_AL_INTERNAL *cal_int = GetNewCalInternal();
+        assert(index < cal->cal_int->size);
+        NVM_STR2(cal_int->version, cal->cal_int->version,
+                 sizeof(cal_int->version) * 8);
+        NVM_STR2(cal_int->size, cal->cal_int->size - 1,
+                 sizeof(cal_int->size) * 8);
+        int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
+        assert(tmp);
+        NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
+        int i;
+        for (i = 0; i < index; ++i) {
+            NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
+                     sizeof(cal_int->data[i]) * 8);
+        }
+        removed_item = cal->cal_int->data[index];
+        for (i = index + 1; i < cal_int->size + 1; ++i) {
+            NVM_STR2(cal_int->data[i - 1], cal->cal_int->data[i],
+                     sizeof(cal_int->data[i - 1]) * 8);
+        }
+        status = DoAtomicSwitch(cal, cal_int);
+        ++iter;
+    } while (!status);
+    //    fprintf(stderr, "Removed in %d attempts\n", iter);
+    return removed_item;
 }
 
 int cal_contains(COW_AL *cal, int num) {
-  int *data = cal->cal_int->data;
-  int i;
-  for (i = 0; i < cal->cal_int->size; ++i) {
-    if (data[i] == num) {
-      return 1;
+    int *data = cal->cal_int->data;
+    int i;
+    for (i = 0; i < cal->cal_int->size; ++i) {
+        if (data[i] == num) {
+            return 1;
+        }
     }
-  }
-  return 0;
+    return 0;
 }
 
 int cal_get(COW_AL *cal, int index) {
-  assert(index < cal->cal_int->size);
-  return cal->cal_int->data[index];
+    assert(index < cal->cal_int->size);
+    return cal->cal_int->data[index];
 }
 
 int size(COW_AL *cal) {
-  return cal->cal_int->size;
+    return cal->cal_int->size;
 }
 
 COW_AL_ITER *create_iter(COW_AL *al) {
-  COW_AL_ITER *cal_iter = (COW_AL_ITER *)malloc(sizeof(cal_iter));
-  assert(cal_iter);
+    COW_AL_ITER *cal_iter = (COW_AL_ITER *)malloc(sizeof(cal_iter));
+    assert(cal_iter);
 
-  cal_iter->cal_int = al->cal_int;
-  return cal_iter;
+    cal_iter->cal_int = al->cal_int;
+    return cal_iter;
 }
 
 int *iter_first(COW_AL_ITER *it) {
-  return it->cal_int->data;
+    return it->cal_int->data;
 }
 
 int *iter_last(COW_AL_ITER *it) {
-  COW_AL_INTERNAL *cal_int = it->cal_int;
-  return cal_int->data + (cal_int->size - 1);
+    COW_AL_INTERNAL *cal_int = it->cal_int;
+    return cal_int->data + (cal_int->size - 1);
 }
 
 void print_cal(COW_AL *cal) {
-  COW_AL_ITER *alist_iter = create_iter(cal);
-  int *ifirst = iter_first(alist_iter);
-  int *ilast = iter_last(alist_iter);
-  while (ifirst) {
-    fprintf(stderr, "%d ", *ifirst);
-    if (ifirst == ilast) {
-      break;
+    COW_AL_ITER *alist_iter = create_iter(cal);
+    int *ifirst = iter_first(alist_iter);
+    int *ilast = iter_last(alist_iter);
+    while (ifirst) {
+        fprintf(stderr, "%d ", *ifirst);
+        if (ifirst == ilast) {
+            break;
+        }
+        ++ifirst;
     }
-    ++ifirst;
-  }
-  fprintf(stderr, "\n");
-  free(alist_iter);
+    fprintf(stderr, "\n");
+    free(alist_iter);
 }
 
 uint64_t sum_cal(COW_AL *cal) {
-  uint64_t sum = 0;
-  COW_AL_ITER *alist_iter = create_iter(cal);
-  int *ifirst = iter_first(alist_iter);
-  int *ilast = iter_last(alist_iter);
-  while (ifirst) {
-    sum += *ifirst;
-    if (ifirst == ilast) {
-      break;
+    uint64_t sum = 0;
+    COW_AL_ITER *alist_iter = create_iter(cal);
+    int *ifirst = iter_first(alist_iter);
+    int *ilast = iter_last(alist_iter);
+    while (ifirst) {
+        sum += *ifirst;
+        if (ifirst == ilast) {
+            break;
+        }
+        ++ifirst;
     }
-    ++ifirst;
-  }
-  free(alist_iter);
-  //    fprintf(stderr, "%d\n", sum);
-  return sum;
+    free(alist_iter);
+    //    fprintf(stderr, "%d\n", sum);
+    return sum;
 }
 
 void *do_work() {
-  NVM_LOCK(ready_lock);
-  ready = 1;
-  NVM_UNLOCK(ready_lock);
+    NVM_LOCK(ready_lock);
+    ready = 1;
+    NVM_UNLOCK(ready_lock);
 
-  uint64_t sum = 0;
-  int count = 0;
-  while (count < NUM_ITER) {
-    remove_cal(alist, 85);
-    sum += sum_cal(alist);
+    uint64_t sum = 0;
+    int count = 0;
+    while (count < NUM_ITER) {
+        remove_cal(alist, 85);
+        sum += sum_cal(alist);
 
-    insert_cal(alist, 205, 210);
-    assert(cal_contains(alist, 210));
-    sum += sum_cal(alist);
+        insert_cal(alist, 205, 210);
+        assert(cal_contains(alist, 210));
+        sum += sum_cal(alist);
 
 #ifdef _FORCE_FAIL
-    if (count == NUM_ITER / 2)
-      exit(0);
+        if (count == NUM_ITER / 2)
+            exit(0);
 #endif
-    add_cal(alist, 105);
-    sum += sum_cal(alist);
+        add_cal(alist, 105);
+        sum += sum_cal(alist);
 
-    ++count;
-  }
-  fprintf(stderr, "child sum is %ld\n", sum);
-  return 0;
+        ++count;
+    }
+    fprintf(stderr, "child sum is %ld\n", sum);
+    return 0;
 }
 
 int main(int argc, char *argv[]) {
-  struct timeval tv_start;
-  struct timeval tv_end;
-  pthread_t th;
+    struct timeval tv_start;
+    struct timeval tv_end;
+    pthread_t th;
 
-  gettimeofday(&tv_start, NULL);
+    gettimeofday(&tv_start, NULL);
 
-  NVM_Initialize();
-  cal_rgn_id = NVM_FindOrCreateRegion("cal", O_RDWR, NULL);
+    NVM_Initialize();
+    cal_rgn_id = NVM_FindOrCreateRegion("cal", O_RDWR, NULL);
 
-  alist = create_cal();
+    alist = create_cal();
 
-  NVM_SetRegionRoot(cal_rgn_id, alist);
+    NVM_SetRegionRoot(cal_rgn_id, alist);
 
-  pthread_create(&th, 0, (void *(*)(void *))do_work, 0);
+    pthread_create(&th, 0, (void *(*)(void *))do_work, 0);
 
-  int t = 0;
-  while (!t) {
-    NVM_LOCK(ready_lock);
-    t = ready;
-    NVM_UNLOCK(ready_lock);
-  }
+    int t = 0;
+    while (!t) {
+        NVM_LOCK(ready_lock);
+        t = ready;
+        NVM_UNLOCK(ready_lock);
+    }
 
-  uint64_t sum = 0;
-  int count = 0;
-  while (count < NUM_ITER) {
-    sum += sum_cal(alist);
+    uint64_t sum = 0;
+    int count = 0;
+    while (count < NUM_ITER) {
+        sum += sum_cal(alist);
 
-    add_cal(alist, 100);
-    sum += sum_cal(alist);
+        add_cal(alist, 100);
+        sum += sum_cal(alist);
 
-    insert_cal(alist, 200, 210);
-    sum += sum_cal(alist);
+        insert_cal(alist, 200, 210);
+        sum += sum_cal(alist);
 
 #ifdef _FORCE_FAIL
-    if (count == NUM_ITER / 2)
-      exit(0);
+        if (count == NUM_ITER / 2)
+            exit(0);
 #endif
-    remove_cal(alist, 50);
-    sum += sum_cal(alist);
+        remove_cal(alist, 50);
+        sum += sum_cal(alist);
 
-    ++count;
-  }
+        ++count;
+    }
 
-  fprintf(stderr, "parent sum is %ld\n", sum);
+    fprintf(stderr, "parent sum is %ld\n", sum);
 
-  pthread_join(th, NULL);
+    pthread_join(th, NULL);
 
-  NVM_CloseRegion(cal_rgn_id);
+    NVM_CloseRegion(cal_rgn_id);
 
 #ifdef NVM_STATS
-  NVM_PrintStats();
+    NVM_PrintStats();
 #endif
 
-  NVM_Finalize();
+    NVM_Finalize();
 
-  gettimeofday(&tv_end, NULL);
-  fprintf(stderr, "time elapsed %ld us\n",
-          tv_end.tv_usec - tv_start.tv_usec +
-              (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+    gettimeofday(&tv_end, NULL);
+    fprintf(stderr, "time elapsed %ld us\n",
+            tv_end.tv_usec - tv_start.tv_usec +
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
 
-  return 0;
+    return 0;
 }
 
 /*

--- a/runtime/tests/data_structures_instrumented/cow_array_list_nvm.c
+++ b/runtime/tests/data_structures_instrumented/cow_array_list_nvm.c
@@ -12,7 +12,6 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
 // This is an example of a program that has been manually instrumented
 // with Atlas internal APIs. This is just for understanding
@@ -23,46 +22,40 @@
 // little performance advantage. If you still want to instrument
 // manually, make sure you compile the manually instrumented program
 // using your favorite compiler, not the Atlas-aware compiler.
+
+#include <assert.h>
+#include <inttypes.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
-#include <pthread.h>
 #include <sys/time.h>
-#include <inttypes.h>
 
-#include "atlas_api.h" 
 #include "atlas_alloc.h"
+#include "atlas_api.h"
 
 #define INITIAL_SIZE 1000
 #define NUM_ITER 10
 
-typedef struct COW_AL_INTERNAL
-{
-    int *data;
-    int size;
-    int version;
-}COW_AL_INTERNAL;
+typedef struct COW_AL_INTERNAL {
+  int *data;
+  int size;
+  int version;
+} COW_AL_INTERNAL;
 
-typedef struct COW_AL
-{
-    COW_AL_INTERNAL * cal_int;
-}COW_AL;
+typedef struct COW_AL { COW_AL_INTERNAL *cal_int; } COW_AL;
 
-typedef struct COW_AL_ITER
-{
-    COW_AL_INTERNAL * cal_int;
-}COW_AL_ITER;
+typedef struct COW_AL_ITER { COW_AL_INTERNAL *cal_int; } COW_AL_ITER;
 
-COW_AL * create_cal();
-void add_cal(COW_AL * cal, int num);
-void insert_cal(COW_AL * cal, int index, int num);
-int remove_cal(COW_AL * cal, int index);
-int cal_contains(COW_AL * cal, int num);
-int cal_get(COW_AL * cal, int index);
-int size(COW_AL * cal);
-COW_AL_ITER * create_iter(COW_AL *);
-int * iter_first(COW_AL_ITER *);
-int * iter_last(COW_AL_ITER *);
+COW_AL *create_cal();
+void add_cal(COW_AL *cal, int num);
+void insert_cal(COW_AL *cal, int index, int num);
+int remove_cal(COW_AL *cal, int index);
+int cal_contains(COW_AL *cal, int num);
+int cal_get(COW_AL *cal, int index);
+int size(COW_AL *cal);
+COW_AL_ITER *create_iter(COW_AL *);
+int *iter_first(COW_AL_ITER *);
+int *iter_last(COW_AL_ITER *);
 void print_cal(COW_AL *);
 
 pthread_mutex_t lock_cal;
@@ -71,319 +64,292 @@ pthread_mutex_t ready_lock;
 int ready = 0;
 int done = 0;
 
-COW_AL * alist = 0;
+COW_AL *alist = 0;
 
 uint32_t cal_rgn_id;
 
-COW_AL_INTERNAL * GetNewCalInternal()
-{
-    COW_AL_INTERNAL * cal_int =
-        (COW_AL_INTERNAL *) nvm_alloc(sizeof(COW_AL_INTERNAL), cal_rgn_id);
-    assert(cal_int);
-    return cal_int;
+COW_AL_INTERNAL *GetNewCalInternal() {
+  COW_AL_INTERNAL *cal_int =
+      (COW_AL_INTERNAL *)nvm_alloc(sizeof(COW_AL_INTERNAL), cal_rgn_id);
+  assert(cal_int);
+  return cal_int;
 }
 
-int DoAtomicSwitch(COW_AL * cal, COW_AL_INTERNAL * cal_int)
-{
-    NVM_LOCK(lock_cal);
-    if (cal->cal_int->version != cal_int->version)
-    {
-        NVM_UNLOCK(lock_cal);
-        return 0;
-    }
-    NVM_STR2(cal_int->version, cal_int->version + 1,
-             sizeof(cal_int->version)*8);
-    NVM_STR2(cal->cal_int, cal_int, sizeof(cal->cal_int)*8);
+int DoAtomicSwitch(COW_AL *cal, COW_AL_INTERNAL *cal_int) {
+  NVM_LOCK(lock_cal);
+  if (cal->cal_int->version != cal_int->version) {
     NVM_UNLOCK(lock_cal);
-    return 1;
+    return 0;
+  }
+  NVM_STR2(cal_int->version, cal_int->version + 1,
+           sizeof(cal_int->version) * 8);
+  NVM_STR2(cal->cal_int, cal_int, sizeof(cal->cal_int) * 8);
+  NVM_UNLOCK(lock_cal);
+  return 1;
 }
 
-COW_AL * create_cal()
-{
-    COW_AL_INTERNAL * cal_int = GetNewCalInternal();
+COW_AL *create_cal() {
+  COW_AL_INTERNAL *cal_int = GetNewCalInternal();
 
-    int * tmp = (int *) nvm_alloc(INITIAL_SIZE * sizeof(int), cal_rgn_id);
+  int *tmp = (int *)nvm_alloc(INITIAL_SIZE * sizeof(int), cal_rgn_id);
+  assert(tmp);
+  int i;
+  for (i = 0; i < INITIAL_SIZE; ++i) {
+    NVM_STR2(tmp[i], i, sizeof(tmp[i]) * 8);
+  }
+
+  NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
+  NVM_STR2(cal_int->size, INITIAL_SIZE, sizeof(cal_int->size) * 8);
+  NVM_STR2(cal_int->version, 0, sizeof(cal_int->version) * 8);
+
+  COW_AL *cal = (COW_AL *)nvm_alloc(sizeof(COW_AL), cal_rgn_id);
+  assert(cal);
+  NVM_STR2(cal->cal_int, cal_int, sizeof(cal->cal_int) * 8);
+
+  return cal;
+}
+
+void add_cal(COW_AL *cal, int num) {
+  int status = 0;
+  int iter = 0;
+  do {
+    COW_AL_INTERNAL *cal_int = GetNewCalInternal();
+    NVM_STR2(cal_int->version, cal->cal_int->version,
+             sizeof(cal_int->version) * 8);
+    NVM_STR2(cal_int->size, cal->cal_int->size + 1, sizeof(cal_int->size) * 8);
+    int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
     assert(tmp);
+    NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
     int i;
-    for (i = 0; i < INITIAL_SIZE; ++i)
-    {
-        NVM_STR2(tmp[i], i, sizeof(tmp[i])*8);
+    for (i = 0; i < cal_int->size - 1; ++i) {
+      NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
+               sizeof(cal_int->data[i]) * 8);
     }
-
-    NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data)*8);
-    NVM_STR2(cal_int->size, INITIAL_SIZE, sizeof(cal_int->size)*8);
-    NVM_STR2(cal_int->version, 0, sizeof(cal_int->version)*8);
-    
-    COW_AL * cal = (COW_AL *) nvm_alloc(sizeof(COW_AL), cal_rgn_id);
-    assert(cal);
-    NVM_STR2(cal->cal_int, cal_int, sizeof(cal->cal_int)*8);
-
-    return cal;
+    NVM_STR2(cal_int->data[cal_int->size - 1], num,
+             sizeof(cal_int->data[cal_int->size - 1]) * 8);
+    status = DoAtomicSwitch(cal, cal_int);
+    ++iter;
+  } while (!status);
+  //    fprintf(stderr, "Added in %d attempts\n", iter);
 }
 
-void add_cal(COW_AL * cal, int num)
-{
-    int status = 0;
-    int iter = 0;
-    do 
-    {
-        COW_AL_INTERNAL * cal_int = GetNewCalInternal();
-        NVM_STR2(cal_int->version, cal->cal_int->version,
-                 sizeof(cal_int->version)*8);
-        NVM_STR2(cal_int->size, cal->cal_int->size+1,
-                 sizeof(cal_int->size)*8);
-        int * tmp = (int *) nvm_alloc(cal_int->size*sizeof(int),
-                                      cal_rgn_id);
-        assert(tmp);
-        NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data)*8);
-        int i;
-        for (i = 0; i < cal_int->size-1; ++ i)
-        {
-            NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
-                     sizeof(cal_int->data[i])*8);
-        }
-        NVM_STR2(cal_int->data[cal_int->size-1], num,
-                 sizeof(cal_int->data[cal_int->size-1])*8);
-        status = DoAtomicSwitch(cal, cal_int);
-        ++iter;
-    }while (!status);
-//    fprintf(stderr, "Added in %d attempts\n", iter);
-}
-
-void insert_cal(COW_AL * cal, int index, int num)
-{
-    int status = 0;
-    int iter = 0;
-    do
-    {
-        COW_AL_INTERNAL * cal_int = GetNewCalInternal();
-        NVM_STR2(cal_int->version, cal->cal_int->version,
-                 sizeof(cal_int->version)*8);
-        NVM_STR2(cal_int->size, cal->cal_int->size+1,
-                 sizeof(cal_int->size)*8);
-        assert(index < cal_int->size);
-        int * tmp = (int *) nvm_alloc(cal_int->size*sizeof(int),
-                                      cal_rgn_id);
-        assert(tmp);
-        NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data)*8);
-        int i;
-        for (i=0; i<index; ++i)
-        {
-            NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
-                     sizeof(cal_int->data[i])*8);
-        }
-        NVM_STR2(cal_int->data[index], num, sizeof(cal_int->data[index])*8);
-        for (i=index+1; i < cal_int->size; ++i)
-        {
-            NVM_STR2(cal_int->data[i], cal->cal_int->data[i-1],
-                     sizeof(cal_int->data[i])*8);
-        }
-        status = DoAtomicSwitch(cal, cal_int);
-        ++iter;
-    }while (!status);
-//    fprintf(stderr, "Inserted in %d attempts\n", iter);
-}
-
-int remove_cal(COW_AL * cal, int index)
-{
-    int status = 0;
-    int iter = 0;
-    int removed_item;
-    do 
-    {
-        COW_AL_INTERNAL * cal_int = GetNewCalInternal();
-        assert(index < cal->cal_int->size);
-        NVM_STR2(cal_int->version, cal->cal_int->version,
-                 sizeof(cal_int->version)*8);
-        NVM_STR2(cal_int->size, cal->cal_int->size-1,
-                 sizeof(cal_int->size)*8);
-        int *tmp = (int *) nvm_alloc(cal_int->size*sizeof(int), cal_rgn_id);
-        assert(tmp);
-        NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data)*8);
-        int i;
-        for (i=0; i<index; ++i)
-        {
-            NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
-                     sizeof(cal_int->data[i])*8);
-        }
-        removed_item = cal->cal_int->data[index];
-        for (i=index+1; i < cal_int->size+1; ++i)
-        {
-            NVM_STR2(cal_int->data[i-1], cal->cal_int->data[i],
-                     sizeof(cal_int->data[i-1])*8);
-        }
-        status = DoAtomicSwitch(cal, cal_int);
-        ++iter;
-    }while (!status);
-//    fprintf(stderr, "Removed in %d attempts\n", iter);
-    return removed_item;
-}
-        
-int cal_contains(COW_AL * cal, int num)
-{
-    int * data = cal->cal_int->data;
+void insert_cal(COW_AL *cal, int index, int num) {
+  int status = 0;
+  int iter = 0;
+  do {
+    COW_AL_INTERNAL *cal_int = GetNewCalInternal();
+    NVM_STR2(cal_int->version, cal->cal_int->version,
+             sizeof(cal_int->version) * 8);
+    NVM_STR2(cal_int->size, cal->cal_int->size + 1, sizeof(cal_int->size) * 8);
+    assert(index < cal_int->size);
+    int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
+    assert(tmp);
+    NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
     int i;
-    for (i=0; i<cal->cal_int->size; ++i)
-        if (data[i] == num) return 1;
-    return 0;
+    for (i = 0; i < index; ++i) {
+      NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
+               sizeof(cal_int->data[i]) * 8);
+    }
+    NVM_STR2(cal_int->data[index], num, sizeof(cal_int->data[index]) * 8);
+    for (i = index + 1; i < cal_int->size; ++i) {
+      NVM_STR2(cal_int->data[i], cal->cal_int->data[i - 1],
+               sizeof(cal_int->data[i]) * 8);
+    }
+    status = DoAtomicSwitch(cal, cal_int);
+    ++iter;
+  } while (!status);
+  //    fprintf(stderr, "Inserted in %d attempts\n", iter);
 }
 
-int cal_get(COW_AL * cal, int index)
-{
+int remove_cal(COW_AL *cal, int index) {
+  int status = 0;
+  int iter = 0;
+  int removed_item;
+  do {
+    COW_AL_INTERNAL *cal_int = GetNewCalInternal();
     assert(index < cal->cal_int->size);
-    return cal->cal_int->data[index];
-}
-
-int size(COW_AL * cal)
-{
-    return cal->cal_int->size;
-}
-
-COW_AL_ITER * create_iter(COW_AL * al)
-{
-    COW_AL_ITER * cal_iter = (COW_AL_ITER *) malloc(sizeof(cal_iter));
-    assert(cal_iter);
-
-    cal_iter->cal_int = al->cal_int;
-    return cal_iter;
-}
-
-int * iter_first(COW_AL_ITER * it)
-{
-    return it->cal_int->data;
-}
-
-int * iter_last(COW_AL_ITER * it)
-{
-    COW_AL_INTERNAL * cal_int = it->cal_int;
-    return cal_int->data + (cal_int->size - 1);
-}
-
-void print_cal(COW_AL * cal)
-{
-    COW_AL_ITER * alist_iter = create_iter(cal);
-    int * ifirst = iter_first(alist_iter);
-    int * ilast = iter_last(alist_iter);
-    while (ifirst)
-    {
-        fprintf(stderr, "%d ", *ifirst);
-        if (ifirst == ilast) break;
-        ++ ifirst;
+    NVM_STR2(cal_int->version, cal->cal_int->version,
+             sizeof(cal_int->version) * 8);
+    NVM_STR2(cal_int->size, cal->cal_int->size - 1, sizeof(cal_int->size) * 8);
+    int *tmp = (int *)nvm_alloc(cal_int->size * sizeof(int), cal_rgn_id);
+    assert(tmp);
+    NVM_STR2(cal_int->data, tmp, sizeof(cal_int->data) * 8);
+    int i;
+    for (i = 0; i < index; ++i) {
+      NVM_STR2(cal_int->data[i], cal->cal_int->data[i],
+               sizeof(cal_int->data[i]) * 8);
     }
-    fprintf(stderr, "\n");
-    free(alist_iter);
-}
-    
-uint64_t sum_cal(COW_AL * cal)
-{
-    uint64_t sum = 0;
-    COW_AL_ITER * alist_iter = create_iter(cal);
-    int * ifirst = iter_first(alist_iter);
-    int * ilast = iter_last(alist_iter);
-    while (ifirst)
-    {
-        sum += *ifirst;
-        if (ifirst == ilast) break;
-        ++ ifirst;
+    removed_item = cal->cal_int->data[index];
+    for (i = index + 1; i < cal_int->size + 1; ++i) {
+      NVM_STR2(cal_int->data[i - 1], cal->cal_int->data[i],
+               sizeof(cal_int->data[i - 1]) * 8);
     }
-    free(alist_iter);
-//    fprintf(stderr, "%d\n", sum);
-    return sum;
+    status = DoAtomicSwitch(cal, cal_int);
+    ++iter;
+  } while (!status);
+  //    fprintf(stderr, "Removed in %d attempts\n", iter);
+  return removed_item;
 }
 
-void * do_work()
-{
+int cal_contains(COW_AL *cal, int num) {
+  int *data = cal->cal_int->data;
+  int i;
+  for (i = 0; i < cal->cal_int->size; ++i) {
+    if (data[i] == num) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+int cal_get(COW_AL *cal, int index) {
+  assert(index < cal->cal_int->size);
+  return cal->cal_int->data[index];
+}
+
+int size(COW_AL *cal) {
+  return cal->cal_int->size;
+}
+
+COW_AL_ITER *create_iter(COW_AL *al) {
+  COW_AL_ITER *cal_iter = (COW_AL_ITER *)malloc(sizeof(cal_iter));
+  assert(cal_iter);
+
+  cal_iter->cal_int = al->cal_int;
+  return cal_iter;
+}
+
+int *iter_first(COW_AL_ITER *it) {
+  return it->cal_int->data;
+}
+
+int *iter_last(COW_AL_ITER *it) {
+  COW_AL_INTERNAL *cal_int = it->cal_int;
+  return cal_int->data + (cal_int->size - 1);
+}
+
+void print_cal(COW_AL *cal) {
+  COW_AL_ITER *alist_iter = create_iter(cal);
+  int *ifirst = iter_first(alist_iter);
+  int *ilast = iter_last(alist_iter);
+  while (ifirst) {
+    fprintf(stderr, "%d ", *ifirst);
+    if (ifirst == ilast) {
+      break;
+    }
+    ++ifirst;
+  }
+  fprintf(stderr, "\n");
+  free(alist_iter);
+}
+
+uint64_t sum_cal(COW_AL *cal) {
+  uint64_t sum = 0;
+  COW_AL_ITER *alist_iter = create_iter(cal);
+  int *ifirst = iter_first(alist_iter);
+  int *ilast = iter_last(alist_iter);
+  while (ifirst) {
+    sum += *ifirst;
+    if (ifirst == ilast) {
+      break;
+    }
+    ++ifirst;
+  }
+  free(alist_iter);
+  //    fprintf(stderr, "%d\n", sum);
+  return sum;
+}
+
+void *do_work() {
+  NVM_LOCK(ready_lock);
+  ready = 1;
+  NVM_UNLOCK(ready_lock);
+
+  uint64_t sum = 0;
+  int count = 0;
+  while (count < NUM_ITER) {
+    remove_cal(alist, 85);
+    sum += sum_cal(alist);
+
+    insert_cal(alist, 205, 210);
+    assert(cal_contains(alist, 210));
+    sum += sum_cal(alist);
+
+#ifdef _FORCE_FAIL
+    if (count == NUM_ITER / 2)
+      exit(0);
+#endif
+    add_cal(alist, 105);
+    sum += sum_cal(alist);
+
+    ++count;
+  }
+  fprintf(stderr, "child sum is %ld\n", sum);
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  struct timeval tv_start;
+  struct timeval tv_end;
+  pthread_t th;
+
+  gettimeofday(&tv_start, NULL);
+
+  NVM_Initialize();
+  cal_rgn_id = NVM_FindOrCreateRegion("cal", O_RDWR, NULL);
+
+  alist = create_cal();
+
+  NVM_SetRegionRoot(cal_rgn_id, alist);
+
+  pthread_create(&th, 0, (void *(*)(void *))do_work, 0);
+
+  int t = 0;
+  while (!t) {
     NVM_LOCK(ready_lock);
-    ready = 1;
+    t = ready;
     NVM_UNLOCK(ready_lock);
+  }
 
-    uint64_t sum = 0;
-    int count = 0;
-    while (count < NUM_ITER)
-    {
-        remove_cal(alist, 85);
-        sum += sum_cal(alist);
+  uint64_t sum = 0;
+  int count = 0;
+  while (count < NUM_ITER) {
+    sum += sum_cal(alist);
 
-        insert_cal(alist, 205, 210);
-        assert(cal_contains(alist, 210));
-        sum += sum_cal(alist);
+    add_cal(alist, 100);
+    sum += sum_cal(alist);
 
-#ifdef _FORCE_FAIL
-    if (count == NUM_ITER/2) exit(0);
-#endif    
-        add_cal(alist, 105);
-        sum += sum_cal(alist);
-
-        ++count;
-    }
-    fprintf(stderr, "child sum is %ld\n", sum);
-    return 0;
-}
-
-int main(int argc, char *argv[])
-{
-    struct timeval tv_start;
-    struct timeval tv_end;
-    pthread_t th;
-
-    gettimeofday(&tv_start, NULL);
-
-    NVM_Initialize();
-    cal_rgn_id = NVM_FindOrCreateRegion("cal", O_RDWR, NULL);
-    
-    alist = create_cal();
-    
-    NVM_SetRegionRoot(cal_rgn_id, alist);
-    
-    pthread_create(&th, 0, (void *(*)(void *))do_work, 0);
-
-    int t=0;
-    while (!t)
-    {
-        NVM_LOCK(ready_lock);
-        t = ready;
-        NVM_UNLOCK(ready_lock);
-    }
-
-    uint64_t sum = 0;
-    int count = 0;
-    while (count < NUM_ITER)
-    {
-        sum += sum_cal(alist);
-
-        add_cal(alist, 100);
-        sum += sum_cal(alist);
-
-        insert_cal(alist, 200, 210);
-        sum += sum_cal(alist);
+    insert_cal(alist, 200, 210);
+    sum += sum_cal(alist);
 
 #ifdef _FORCE_FAIL
-    if (count == NUM_ITER/2) exit(0);
-#endif    
-        remove_cal(alist, 50);
-        sum += sum_cal(alist);
+    if (count == NUM_ITER / 2)
+      exit(0);
+#endif
+    remove_cal(alist, 50);
+    sum += sum_cal(alist);
 
-        ++count;
-    }
+    ++count;
+  }
 
-    fprintf(stderr, "parent sum is %ld\n", sum);
+  fprintf(stderr, "parent sum is %ld\n", sum);
 
-    pthread_join(th, NULL);
+  pthread_join(th, NULL);
 
-    NVM_CloseRegion(cal_rgn_id);
+  NVM_CloseRegion(cal_rgn_id);
 
 #ifdef NVM_STATS
-    NVM_PrintStats();
+  NVM_PrintStats();
 #endif
-    
-    NVM_Finalize();
 
-    gettimeofday(&tv_end, NULL);
-    fprintf(stderr, "time elapsed %ld us\n",
-            tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
-    
-    return 0;
+  NVM_Finalize();
+
+  gettimeofday(&tv_end, NULL);
+  fprintf(stderr, "time elapsed %ld us\n",
+          tv_end.tv_usec - tv_start.tv_usec +
+              (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+
+  return 0;
 }
 
 /*

--- a/runtime/tests/data_structures_instrumented/queue_nvm.c
+++ b/runtime/tests/data_structures_instrumented/queue_nvm.c
@@ -39,15 +39,15 @@
 #include "atlas_api.h"
 
 typedef struct node_t {
-  int val;
-  struct node_t *next;
+    int val;
+    struct node_t *next;
 } node_t;
 
 typedef struct queue_t {
-  node_t *head;
-  node_t *tail;
-  pthread_mutex_t *head_lock;
-  pthread_mutex_t *tail_lock;
+    node_t *head;
+    node_t *tail;
+    pthread_mutex_t *head_lock;
+    pthread_mutex_t *tail_lock;
 } queue_t;
 
 queue_t *Q;
@@ -63,198 +63,198 @@ uint32_t queue_rgn_id;
 void traverse();
 
 void initialize() {
-  void *rgn_root = NVM_GetRegionRoot(queue_rgn_id);
-  if (rgn_root) {
-    Q = (queue_t *)rgn_root;
-    Q->head_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
-    pthread_mutex_init(Q->head_lock, NULL);
-    Q->tail_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
-    pthread_mutex_init(Q->tail_lock, NULL);
+    void *rgn_root = NVM_GetRegionRoot(queue_rgn_id);
+    if (rgn_root) {
+        Q = (queue_t *)rgn_root;
+        Q->head_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+        pthread_mutex_init(Q->head_lock, NULL);
+        Q->tail_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+        pthread_mutex_init(Q->tail_lock, NULL);
 
-    fprintf(stderr, "Found queue at %p\n", Q);
-    traverse();
-  } else {
+        fprintf(stderr, "Found queue at %p\n", Q);
+        traverse();
+    } else {
+        node_t *node =
+#if defined(_USE_MALLOC)
+            (node_t *)malloc(sizeof(node_t));
+#else
+            (node_t *)nvm_alloc(sizeof(node_t), queue_rgn_id);
+#endif
+        assert(node);
+
+        NVM_STR2(node->val, -1, sizeof(int) * 8); // dummy value
+        NVM_STR2(node->next, NULL, sizeof(node_t *) * 8);
+
+#if defined(_USE_MALLOC)
+        Q = (queue_t *)malloc(sizeof(queue_t));
+#else
+        Q = (queue_t *)nvm_alloc(sizeof(queue_t), queue_rgn_id);
+#endif
+        assert(Q);
+        fprintf(stderr, "Created Q at %p\n", Q);
+
+        Q->head_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+        pthread_mutex_init(Q->head_lock, NULL);
+        Q->tail_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+        pthread_mutex_init(Q->tail_lock, NULL);
+
+        NVM_BEGIN_DURABLE();
+
+        NVM_STR2(Q->head, node, sizeof(node_t *) * 8);
+        NVM_STR2(Q->tail, node, sizeof(node_t *) * 8);
+
+        NVM_SetRegionRoot(queue_rgn_id, Q);
+
+        NVM_END_DURABLE();
+    }
+}
+
+// not thread safe
+void traverse() {
+    assert(Q);
+    assert(Q->head);
+    assert(Q->tail);
+
+    node_t *t = Q->head;
+    fprintf(stderr, "Contents of existing queue: ");
+    int elem_count = 0;
+    while (t) {
+        //        fprintf(stderr, "%p %d ", t, t->val);
+        ++elem_count;
+        t = t->next;
+    }
+    fprintf(stderr, "elem_count = %d\n", elem_count);
+}
+
+void enqueue(int val) {
     node_t *node =
 #if defined(_USE_MALLOC)
         (node_t *)malloc(sizeof(node_t));
 #else
         (node_t *)nvm_alloc(sizeof(node_t), queue_rgn_id);
 #endif
+
     assert(node);
 
-    NVM_STR2(node->val, -1, sizeof(int) * 8); // dummy value
+    NVM_STR2(node->val, val, sizeof(int) * 8);
     NVM_STR2(node->next, NULL, sizeof(node_t *) * 8);
 
-#if defined(_USE_MALLOC)
-    Q = (queue_t *)malloc(sizeof(queue_t));
-#else
-    Q = (queue_t *)nvm_alloc(sizeof(queue_t), queue_rgn_id);
-#endif
-    assert(Q);
-    fprintf(stderr, "Created Q at %p\n", Q);
-
-    Q->head_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
-    pthread_mutex_init(Q->head_lock, NULL);
-    Q->tail_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
-    pthread_mutex_init(Q->tail_lock, NULL);
-
-    NVM_BEGIN_DURABLE();
-
-    NVM_STR2(Q->head, node, sizeof(node_t *) * 8);
-    NVM_STR2(Q->tail, node, sizeof(node_t *) * 8);
-
-    NVM_SetRegionRoot(queue_rgn_id, Q);
-
-    NVM_END_DURABLE();
-  }
-}
-
-// not thread safe
-void traverse() {
-  assert(Q);
-  assert(Q->head);
-  assert(Q->tail);
-
-  node_t *t = Q->head;
-  fprintf(stderr, "Contents of existing queue: ");
-  int elem_count = 0;
-  while (t) {
-    //        fprintf(stderr, "%p %d ", t, t->val);
-    ++elem_count;
-    t = t->next;
-  }
-  fprintf(stderr, "elem_count = %d\n", elem_count);
-}
-
-void enqueue(int val) {
-  node_t *node =
-#if defined(_USE_MALLOC)
-      (node_t *)malloc(sizeof(node_t));
-#else
-      (node_t *)nvm_alloc(sizeof(node_t), queue_rgn_id);
-#endif
-
-  assert(node);
-
-  NVM_STR2(node->val, val, sizeof(int) * 8);
-  NVM_STR2(node->next, NULL, sizeof(node_t *) * 8);
-
-  NVM_LOCK(*(Q->tail_lock));
-  NVM_STR2(Q->tail->next, node, sizeof(node_t *) * 8);
+    NVM_LOCK(*(Q->tail_lock));
+    NVM_STR2(Q->tail->next, node, sizeof(node_t *) * 8);
 #ifdef _FORCE_FAIL
-  if (val == NUM_ITEMS / 2)
-    exit(0);
+    if (val == NUM_ITEMS / 2)
+        exit(0);
 #endif
-  NVM_STR2(Q->tail, node, sizeof(node_t *) * 8);
-  NVM_UNLOCK(*(Q->tail_lock));
+    NVM_STR2(Q->tail, node, sizeof(node_t *) * 8);
+    NVM_UNLOCK(*(Q->tail_lock));
 }
 
 int dequeue(int *valp) {
-  NVM_LOCK(*(Q->head_lock));
-  // note that not everything of type node_t is persistent
-  // In the following statement, we have a transient pointer to
-  // persistent data which is just fine. If there is a crash, the
-  // transient pointer goes away.
-  node_t *node = Q->head;
-  node_t *new_head = node->next;
-  if (new_head == NULL) {
-    NVM_UNLOCK(*(Q->head_lock));
-    return 0;
-  }
-  *valp = new_head->val;
+    NVM_LOCK(*(Q->head_lock));
+    // note that not everything of type node_t is persistent
+    // In the following statement, we have a transient pointer to
+    // persistent data which is just fine. If there is a crash, the
+    // transient pointer goes away.
+    node_t *node = Q->head;
+    node_t *new_head = node->next;
+    if (new_head == NULL) {
+        NVM_UNLOCK(*(Q->head_lock));
+        return 0;
+    }
+    *valp = new_head->val;
 #ifdef _FORCE_FAIL
-  if (*valp == NUM_ITEMS / 4)
-    exit(0);
+    if (*valp == NUM_ITEMS / 4)
+        exit(0);
 #endif
-  NVM_STR2(Q->head, new_head, sizeof(node_t *) * 8);
-  NVM_UNLOCK(*(Q->head_lock));
+    NVM_STR2(Q->head, new_head, sizeof(node_t *) * 8);
+    NVM_UNLOCK(*(Q->head_lock));
 
 #if defined(_USE_MALLOC)
-  free(node);
+    free(node);
 #else
-  nvm_free(node);
+    nvm_free(node);
 #endif
-  return 1;
+    return 1;
 }
 
 void *do_work() {
-  // TODO All lock/unlock must be instrumented, regardless of whether the
-  // critical sections have accesses to persistent locations
-  NVM_LOCK(ready_lock);
-  ready = 1;
-  NVM_UNLOCK(ready_lock);
+    // TODO All lock/unlock must be instrumented, regardless of whether the
+    // critical sections have accesses to persistent locations
+    NVM_LOCK(ready_lock);
+    ready = 1;
+    NVM_UNLOCK(ready_lock);
 
-  int global_count = 0;
-  int t = 0;
-  while (1) {
-    int val;
-    int status = dequeue(&val);
-    if (status) {
-      ++global_count;
-    } else if (t) {
-      break;
+    int global_count = 0;
+    int t = 0;
+    while (1) {
+        int val;
+        int status = dequeue(&val);
+        if (status) {
+            ++global_count;
+        } else if (t) {
+            break;
+        }
+
+        NVM_LOCK(done_lock);
+        t = done;
+        NVM_UNLOCK(done_lock);
     }
-
-    NVM_LOCK(done_lock);
-    t = done;
-    NVM_UNLOCK(done_lock);
-  }
-  fprintf(stderr, "Total # items dequeued is %d\n", global_count);
+    fprintf(stderr, "Total # items dequeued is %d\n", global_count);
 
 #ifdef NVM_STATS
-  NVM_PrintStats();
+    NVM_PrintStats();
 #endif
 
-  return 0;
+    return 0;
 }
 
 int main() {
-  pthread_t thread;
-  struct timeval tv_start;
-  struct timeval tv_end;
+    pthread_t thread;
+    struct timeval tv_start;
+    struct timeval tv_end;
 
-  gettimeofday(&tv_start, NULL);
+    gettimeofday(&tv_start, NULL);
 
-  NVM_Initialize();
-  queue_rgn_id = NVM_FindOrCreateRegion("queue", O_RDWR, NULL);
+    NVM_Initialize();
+    queue_rgn_id = NVM_FindOrCreateRegion("queue", O_RDWR, NULL);
 
-  initialize();
+    initialize();
 
-  pthread_create(&thread, 0, (void *(*)(void *))do_work, 0);
+    pthread_create(&thread, 0, (void *(*)(void *))do_work, 0);
 
-  // wait for the child to be ready
-  int t = 0;
-  while (!t) {
-    NVM_LOCK(ready_lock);
-    t = ready;
-    NVM_UNLOCK(ready_lock);
-  }
+    // wait for the child to be ready
+    int t = 0;
+    while (!t) {
+        NVM_LOCK(ready_lock);
+        t = ready;
+        NVM_UNLOCK(ready_lock);
+    }
 
-  int i;
-  for (i = 0; i < NUM_ITEMS; ++i) {
-    enqueue(i);
-  }
+    int i;
+    for (i = 0; i < NUM_ITEMS; ++i) {
+        enqueue(i);
+    }
 
-  NVM_LOCK(done_lock);
-  done = 1;
-  NVM_UNLOCK(done_lock);
+    NVM_LOCK(done_lock);
+    done = 1;
+    NVM_UNLOCK(done_lock);
 
-  pthread_join(thread, NULL);
+    pthread_join(thread, NULL);
 
-  NVM_CloseRegion(queue_rgn_id);
+    NVM_CloseRegion(queue_rgn_id);
 
 #ifdef NVM_STATS
-  NVM_PrintStats();
+    NVM_PrintStats();
 #endif
 
-  NVM_Finalize();
+    NVM_Finalize();
 
-  fprintf(stderr, "Total # items enqueued is %d\n", NUM_ITEMS);
+    fprintf(stderr, "Total # items enqueued is %d\n", NUM_ITEMS);
 
-  gettimeofday(&tv_end, NULL);
-  fprintf(stderr, "time elapsed %ld us\n",
-          tv_end.tv_usec - tv_start.tv_usec +
-              (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+    gettimeofday(&tv_end, NULL);
+    fprintf(stderr, "time elapsed %ld us\n",
+            tv_end.tv_usec - tv_start.tv_usec +
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
 
-  return 0;
+    return 0;
 }

--- a/runtime/tests/data_structures_instrumented/queue_nvm.c
+++ b/runtime/tests/data_structures_instrumented/queue_nvm.c
@@ -12,7 +12,6 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
 // Adapted from Michael & Scott, "Simple, Fast, and Practical Non-Blocking
 // and Blocking Concurrent Queue Algorithms", PODC 1996.
@@ -26,33 +25,32 @@
 // little performance advantage. If you still want to instrument
 // manually, make sure you compile the manually instrumented program
 // using your favorite compiler, not the Atlas-aware compiler.
-#include <stdio.h>
-#include <stdlib.h>
+
+#include <assert.h>
 #include <pthread.h>
 #include <sched.h>
-#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <sys/time.h>
 
 #define NUM_ITEMS 100000
 
-#include "atlas_api.h" 
 #include "atlas_alloc.h"
+#include "atlas_api.h"
 
-typedef struct node_t
-{
-    int val;
-    struct node_t * next;
-}node_t;
+typedef struct node_t {
+  int val;
+  struct node_t *next;
+} node_t;
 
-typedef struct queue_t 
-{
-    node_t * head;
-    node_t * tail;
-    pthread_mutex_t * head_lock;
-    pthread_mutex_t * tail_lock;
-}queue_t;
+typedef struct queue_t {
+  node_t *head;
+  node_t *tail;
+  pthread_mutex_t *head_lock;
+  pthread_mutex_t *tail_lock;
+} queue_t;
 
-queue_t * Q;
+queue_t *Q;
 
 int ready = 0;
 int done = 0;
@@ -64,206 +62,199 @@ uint32_t queue_rgn_id;
 
 void traverse();
 
-void initialize()
-{
-    void * rgn_root = NVM_GetRegionRoot(queue_rgn_id);
-    if (rgn_root) 
-    {
-        Q = (queue_t *)rgn_root;
-        Q->head_lock = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
-        pthread_mutex_init(Q->head_lock, NULL);
-        Q->tail_lock = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
-        pthread_mutex_init(Q->tail_lock, NULL);
+void initialize() {
+  void *rgn_root = NVM_GetRegionRoot(queue_rgn_id);
+  if (rgn_root) {
+    Q = (queue_t *)rgn_root;
+    Q->head_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+    pthread_mutex_init(Q->head_lock, NULL);
+    Q->tail_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+    pthread_mutex_init(Q->tail_lock, NULL);
 
-        fprintf(stderr, "Found queue at %p\n", Q);
-        traverse();
-    }
-    else
-    {
-        node_t * node =
+    fprintf(stderr, "Found queue at %p\n", Q);
+    traverse();
+  } else {
+    node_t *node =
 #if defined(_USE_MALLOC)
-            (node_t *) malloc(sizeof(node_t));
-#else        
-            (node_t *) nvm_alloc(sizeof(node_t), queue_rgn_id);
-#endif            
-        assert(node);
-
-        NVM_STR2(node->val, -1, sizeof(int)*8); // dummy value
-        NVM_STR2(node->next, NULL, sizeof(node_t*)*8);
-
-#if defined(_USE_MALLOC)
-        Q = (queue_t *) malloc(sizeof(queue_t));
+        (node_t *)malloc(sizeof(node_t));
 #else
-        Q = (queue_t *) nvm_alloc(sizeof(queue_t), queue_rgn_id);
-#endif        
-        assert(Q);
-        fprintf(stderr, "Created Q at %p\n", Q);
-        
-        Q->head_lock = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
-        pthread_mutex_init(Q->head_lock, NULL);
-        Q->tail_lock = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
-        pthread_mutex_init(Q->tail_lock, NULL);
+        (node_t *)nvm_alloc(sizeof(node_t), queue_rgn_id);
+#endif
+    assert(node);
 
-        NVM_BEGIN_DURABLE();
+    NVM_STR2(node->val, -1, sizeof(int) * 8); // dummy value
+    NVM_STR2(node->next, NULL, sizeof(node_t *) * 8);
 
-        NVM_STR2(Q->head, node, sizeof(node_t*)*8);
-        NVM_STR2(Q->tail, node, sizeof(node_t*)*8);
-        
-        NVM_SetRegionRoot(queue_rgn_id, Q);
+#if defined(_USE_MALLOC)
+    Q = (queue_t *)malloc(sizeof(queue_t));
+#else
+    Q = (queue_t *)nvm_alloc(sizeof(queue_t), queue_rgn_id);
+#endif
+    assert(Q);
+    fprintf(stderr, "Created Q at %p\n", Q);
 
-        NVM_END_DURABLE();
-    }
+    Q->head_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+    pthread_mutex_init(Q->head_lock, NULL);
+    Q->tail_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+    pthread_mutex_init(Q->tail_lock, NULL);
+
+    NVM_BEGIN_DURABLE();
+
+    NVM_STR2(Q->head, node, sizeof(node_t *) * 8);
+    NVM_STR2(Q->tail, node, sizeof(node_t *) * 8);
+
+    NVM_SetRegionRoot(queue_rgn_id, Q);
+
+    NVM_END_DURABLE();
+  }
 }
 
 // not thread safe
-void traverse()
-{
-    assert(Q);
-    assert(Q->head);
-    assert(Q->tail);
+void traverse() {
+  assert(Q);
+  assert(Q->head);
+  assert(Q->tail);
 
-    node_t * t = Q->head;
-    fprintf(stderr, "Contents of existing queue: ");
-    int elem_count = 0;
-    while (t)
-    {
-//        fprintf(stderr, "%p %d ", t, t->val);
-        ++elem_count;
-        t = t->next;
-    }
-    fprintf(stderr, "elem_count = %d\n", elem_count);
+  node_t *t = Q->head;
+  fprintf(stderr, "Contents of existing queue: ");
+  int elem_count = 0;
+  while (t) {
+    //        fprintf(stderr, "%p %d ", t, t->val);
+    ++elem_count;
+    t = t->next;
+  }
+  fprintf(stderr, "elem_count = %d\n", elem_count);
 }
 
-void enqueue(int val)
-{
-    node_t * node =
+void enqueue(int val) {
+  node_t *node =
 #if defined(_USE_MALLOC)
-        (node_t *) malloc(sizeof(node_t));
+      (node_t *)malloc(sizeof(node_t));
 #else
-    (node_t *) nvm_alloc(sizeof(node_t), queue_rgn_id);
+      (node_t *)nvm_alloc(sizeof(node_t), queue_rgn_id);
 #endif
-    
-    assert(node);
 
-    NVM_STR2(node->val, val, sizeof(int)*8);
-    NVM_STR2(node->next, NULL, sizeof(node_t*)*8);
+  assert(node);
 
-    NVM_LOCK(*(Q->tail_lock));
-    NVM_STR2(Q->tail->next, node, sizeof(node_t*)*8);
+  NVM_STR2(node->val, val, sizeof(int) * 8);
+  NVM_STR2(node->next, NULL, sizeof(node_t *) * 8);
+
+  NVM_LOCK(*(Q->tail_lock));
+  NVM_STR2(Q->tail->next, node, sizeof(node_t *) * 8);
 #ifdef _FORCE_FAIL
-    if (val == NUM_ITEMS/2) exit(0);
-#endif    
-    NVM_STR2(Q->tail, node, sizeof(node_t*)*8);
-    NVM_UNLOCK(*(Q->tail_lock));
+  if (val == NUM_ITEMS / 2)
+    exit(0);
+#endif
+  NVM_STR2(Q->tail, node, sizeof(node_t *) * 8);
+  NVM_UNLOCK(*(Q->tail_lock));
 }
 
-int dequeue(int * valp)
-{
-    NVM_LOCK(*(Q->head_lock));
-    // note that not everything of type node_t is persistent
-    // In the following statement, we have a transient pointer to
-    // persistent data which is just fine. If there is a crash, the
-    // transient pointer goes away.
-    node_t * node = Q->head; 
-    node_t * new_head = node->next;
-    if (new_head == NULL)
-    {
-        NVM_UNLOCK(*(Q->head_lock));
-        return 0;
-    }
-    *valp = new_head->val;
-#ifdef _FORCE_FAIL
-    if (*valp == NUM_ITEMS/4) exit(0);
-#endif    
-    NVM_STR2(Q->head, new_head, sizeof(node_t*)*8);
+int dequeue(int *valp) {
+  NVM_LOCK(*(Q->head_lock));
+  // note that not everything of type node_t is persistent
+  // In the following statement, we have a transient pointer to
+  // persistent data which is just fine. If there is a crash, the
+  // transient pointer goes away.
+  node_t *node = Q->head;
+  node_t *new_head = node->next;
+  if (new_head == NULL) {
     NVM_UNLOCK(*(Q->head_lock));
+    return 0;
+  }
+  *valp = new_head->val;
+#ifdef _FORCE_FAIL
+  if (*valp == NUM_ITEMS / 4)
+    exit(0);
+#endif
+  NVM_STR2(Q->head, new_head, sizeof(node_t *) * 8);
+  NVM_UNLOCK(*(Q->head_lock));
 
 #if defined(_USE_MALLOC)
-    free(node);
-#else    
-    nvm_free(node);
-#endif    
-    return 1;
+  free(node);
+#else
+  nvm_free(node);
+#endif
+  return 1;
 }
 
-void * do_work()
-{
-    // TODO All lock/unlock must be instrumented, regardless of whether the
-    // critical sections have accesses to persistent locations
-    NVM_LOCK(ready_lock);
-    ready = 1;
-    NVM_UNLOCK(ready_lock);
+void *do_work() {
+  // TODO All lock/unlock must be instrumented, regardless of whether the
+  // critical sections have accesses to persistent locations
+  NVM_LOCK(ready_lock);
+  ready = 1;
+  NVM_UNLOCK(ready_lock);
 
-    int global_count = 0;
-    int t = 0;
-    while (1)
-    {
-        int val;
-        int status = dequeue(&val);
-        if (status) ++ global_count;
-        else if (t) break;
-
-        NVM_LOCK(done_lock);
-        t = done;
-        NVM_UNLOCK(done_lock);
+  int global_count = 0;
+  int t = 0;
+  while (1) {
+    int val;
+    int status = dequeue(&val);
+    if (status) {
+      ++global_count;
+    } else if (t) {
+      break;
     }
-    fprintf(stderr, "Total # items dequeued is %d\n", global_count);
-
-#ifdef NVM_STATS
-    NVM_PrintStats();
-#endif    
-
-    return 0;
-}
-
-int main()
-{
-    pthread_t thread;
-    struct timeval tv_start;
-    struct timeval tv_end;
-    
-    gettimeofday(&tv_start, NULL);
-    
-    NVM_Initialize();
-    queue_rgn_id = NVM_FindOrCreateRegion("queue", O_RDWR, NULL);
-
-    initialize();
-
-    pthread_create(&thread, 0, (void *(*)(void *))do_work, 0);
-
-    // wait for the child to be ready
-    int t = 0;
-    while (!t)
-    {
-        NVM_LOCK(ready_lock);
-        t = ready;
-        NVM_UNLOCK(ready_lock);
-    }
-
-    int i;
-    for (i = 0; i < NUM_ITEMS; ++i)
-        enqueue(i);
 
     NVM_LOCK(done_lock);
-    done = 1;
+    t = done;
     NVM_UNLOCK(done_lock);
-
-    pthread_join(thread, NULL);
-
-    NVM_CloseRegion(queue_rgn_id);
+  }
+  fprintf(stderr, "Total # items dequeued is %d\n", global_count);
 
 #ifdef NVM_STATS
-    NVM_PrintStats();
-#endif    
+  NVM_PrintStats();
+#endif
 
-    NVM_Finalize();
+  return 0;
+}
 
-    fprintf(stderr, "Total # items enqueued is %d\n", NUM_ITEMS);
-    
-    gettimeofday(&tv_end, NULL);
-    fprintf(stderr, "time elapsed %ld us\n",
-            tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
-    
-    return 0;
+int main() {
+  pthread_t thread;
+  struct timeval tv_start;
+  struct timeval tv_end;
+
+  gettimeofday(&tv_start, NULL);
+
+  NVM_Initialize();
+  queue_rgn_id = NVM_FindOrCreateRegion("queue", O_RDWR, NULL);
+
+  initialize();
+
+  pthread_create(&thread, 0, (void *(*)(void *))do_work, 0);
+
+  // wait for the child to be ready
+  int t = 0;
+  while (!t) {
+    NVM_LOCK(ready_lock);
+    t = ready;
+    NVM_UNLOCK(ready_lock);
+  }
+
+  int i;
+  for (i = 0; i < NUM_ITEMS; ++i) {
+    enqueue(i);
+  }
+
+  NVM_LOCK(done_lock);
+  done = 1;
+  NVM_UNLOCK(done_lock);
+
+  pthread_join(thread, NULL);
+
+  NVM_CloseRegion(queue_rgn_id);
+
+#ifdef NVM_STATS
+  NVM_PrintStats();
+#endif
+
+  NVM_Finalize();
+
+  fprintf(stderr, "Total # items enqueued is %d\n", NUM_ITEMS);
+
+  gettimeofday(&tv_end, NULL);
+  fprintf(stderr, "time elapsed %ld us\n",
+          tv_end.tv_usec - tv_start.tv_usec +
+              (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+
+  return 0;
 }

--- a/runtime/tests/data_structures_instrumented/sll_nvm.cpp
+++ b/runtime/tests/data_structures_instrumented/sll_nvm.cpp
@@ -12,7 +12,6 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
 // This is an example of a program that has been manually instrumented
 // with Atlas internal APIs. This is just for understanding
@@ -23,178 +22,168 @@
 // little performance advantage. If you still want to instrument
 // manually, make sure you compile the manually instrumented program
 // using your favorite compiler, not the Atlas-aware compiler.
-#include <stdio.h>
-#include <stdlib.h>
+
 #include <alloca.h>
 #include <assert.h>
-#include <string.h>
 #include <complex>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/time.h>
 
-#include "atlas_api.h"
 #include "atlas_alloc.h"
+#include "atlas_api.h"
 
-typedef struct Node
-{
-    char *Data;
-    struct Node *Next;
-}Node;
+typedef struct Node {
+  char *Data;
+  struct Node *Next;
+} Node;
 
-typedef struct SearchResult
-{
-    Node* Match;
-    Node* Prev;
-}SearchResult;
-
+typedef struct SearchResult {
+  Node *Match;
+  Node *Prev;
+} SearchResult;
 
 Node *SLL = NULL;
 Node *InsertAfter = NULL;
 
 uint32_t sll_rgn_id;
 
-Node *createSingleNode(int Num, int NumBlanks)
-{
-#if defined(_USE_MALLOC)    
-    Node *node = (Node *) malloc(sizeof(Node));
+Node *createSingleNode(int Num, int NumBlanks) {
+#if defined(_USE_MALLOC)
+  Node *node = (Node *)malloc(sizeof(Node));
 #else
-    Node *node = (Node *) nvm_alloc(sizeof(Node), sll_rgn_id);
-#endif    
-    int num_digits = log10(Num)+1;
-    int len = num_digits+NumBlanks;
-#if defined(_USE_MALLOC)    
-    char* d = (char*) malloc((len+1)*sizeof(char));
+  Node *node = (Node *)nvm_alloc(sizeof(Node), sll_rgn_id);
+#endif
+  int num_digits = log10(Num) + 1;
+  int len = num_digits + NumBlanks;
+#if defined(_USE_MALLOC)
+  char *d = (char *)malloc((len + 1) * sizeof(char));
 #else
-    char* d = (char*) nvm_alloc((len+1)*sizeof(char), sll_rgn_id);
-#endif    
-                                  
-    NVM_STR2(node->Data, d, sizeof(char*)*8); 
-    
-    char *tmp_s = (char *) alloca(
-        (num_digits > NumBlanks ? num_digits+1 : NumBlanks+1)*sizeof(char));
-    sprintf(tmp_s, "%d", Num);
+  char *d = (char *)nvm_alloc((len + 1) * sizeof(char), sll_rgn_id);
+#endif
 
-    NVM_MEMCPY(node->Data, tmp_s, num_digits);
-        
-    for (int i = 0; i < NumBlanks; ++i) tmp_s[i] = ' ';
-    NVM_MEMCPY(node->Data + num_digits, tmp_s, NumBlanks);
-    NVM_STR2(node->Data[num_digits+NumBlanks], '\0', sizeof(char)*8);
-    return node;
+  NVM_STR2(node->Data, d, sizeof(char *) * 8);
+
+  char *tmp_s = (char *)alloca(
+      (num_digits > NumBlanks ? num_digits + 1 : NumBlanks + 1) * sizeof(char));
+  sprintf(tmp_s, "%d", Num);
+
+  NVM_MEMCPY(node->Data, tmp_s, num_digits);
+
+  for (int i = 0; i < NumBlanks; ++i) {
+    tmp_s[i] = ' ';
+  }
+  NVM_MEMCPY(node->Data + num_digits, tmp_s, NumBlanks);
+  NVM_STR2(node->Data[num_digits + NumBlanks], '\0', sizeof(char) * 8);
+  return node;
 }
 
-Node *insertPass1(int Num, int NumBlanks, int NumFAI) 
-{
-    Node *node = createSingleNode(Num, NumBlanks);
-    
-    // In pass 1, the new node is the last node in the list
-    NVM_STR2(node->Next, NULL, sizeof(node->Next)*8);
+Node *insertPass1(int Num, int NumBlanks, int NumFAI) {
+  Node *node = createSingleNode(Num, NumBlanks);
 
-    NVM_BEGIN_DURABLE();
-    
-    if (!SLL)
-    {
-        NVM_STR2(SLL, node, sizeof(SLL)*8); // write-once
-        InsertAfter = node;
-    }
-    else
-    {
-        NVM_STR2(InsertAfter->Next, node, sizeof(InsertAfter->Next)*8);
-        InsertAfter = node;
-    }
-    NVM_END_DURABLE();
-    
-    return node;
+  // In pass 1, the new node is the last node in the list
+  NVM_STR2(node->Next, NULL, sizeof(node->Next) * 8);
+
+  NVM_BEGIN_DURABLE();
+
+  if (!SLL) {
+    NVM_STR2(SLL, node, sizeof(SLL) * 8); // write-once
+    InsertAfter = node;
+  } else {
+    NVM_STR2(InsertAfter->Next, node, sizeof(InsertAfter->Next) * 8);
+    InsertAfter = node;
+  }
+  NVM_END_DURABLE();
+
+  return node;
 }
 
-Node *insertPass2(int Num, int NumBlanks, int NumFAI)
-{
-    Node** new_nodes = (Node**) malloc (NumFAI*sizeof(Node*));
-    Node* list_iter = InsertAfter->Next;
-    for (int i=0; i < NumFAI; i++)
-    {
-        new_nodes[i] = createSingleNode(Num + i, NumBlanks);
-        if (list_iter != NULL)
-        {
-            NVM_STR2(new_nodes[i]->Next, list_iter, sizeof(list_iter)*8);
-        }
-        else
-            break;
-        list_iter = list_iter->Next;
+Node *insertPass2(int Num, int NumBlanks, int NumFAI) {
+  Node **new_nodes = (Node **)malloc(NumFAI * sizeof(Node *));
+  Node *list_iter = InsertAfter->Next;
+  for (int i = 0; i < NumFAI; i++) {
+    new_nodes[i] = createSingleNode(Num + i, NumBlanks);
+    if (list_iter != NULL) {
+      NVM_STR2(new_nodes[i]->Next, list_iter, sizeof(list_iter) * 8);
+    } else {
+      break;
     }
+    list_iter = list_iter->Next;
+  }
 
-    NVM_BEGIN_DURABLE();
-    
-    for (int i=0; i < NumFAI; i++)
-    {
-        NVM_STR2(InsertAfter->Next, new_nodes[i], sizeof(InsertAfter->Next)*8);
-        if (new_nodes[i]->Next != NULL)
-             InsertAfter = new_nodes[i]->Next;
-        else 
-        {
-             InsertAfter = new_nodes[i];
-             break;
-        }
+  NVM_BEGIN_DURABLE();
+
+  for (int i = 0; i < NumFAI; i++) {
+    NVM_STR2(InsertAfter->Next, new_nodes[i], sizeof(InsertAfter->Next) * 8);
+    if (new_nodes[i]->Next != NULL) {
+      InsertAfter = new_nodes[i]->Next;
+    } else {
+      InsertAfter = new_nodes[i];
+      break;
     }
-    
-    NVM_END_DURABLE();
+  }
 
-    return InsertAfter;
+  NVM_END_DURABLE();
+
+  return InsertAfter;
 }
 
-long printSLL()
-{
-    long sum = 0;
-    Node *tnode = SLL;
-    while (tnode)
-    {
-//        fprintf(stderr, "%s ", tnode->Data);
-        sum += atoi(tnode->Data);
-        tnode = tnode->Next;
-    }
-//    fprintf(stderr, "\n");
-    return sum;
+long printSLL() {
+  long sum = 0;
+  Node *tnode = SLL;
+  while (tnode) {
+    //        fprintf(stderr, "%s ", tnode->Data);
+    sum += atoi(tnode->Data);
+    tnode = tnode->Next;
+  }
+  //    fprintf(stderr, "\n");
+  return sum;
 }
 
-int main(int argc, char *argv[])
-{
-    struct timeval tv_start;
-    struct timeval tv_end;
-    gettimeofday(&tv_start, NULL);
-    
-    if (argc != 4)
-    {
-        fprintf(stderr, "usage: a.out numInts numBlanks numFAItems\n");
-        exit(0);
-    }
-    int N = atoi(argv[1]);
-    int K = atoi(argv[2]);
-    int X = atoi(argv[3]);
-    fprintf(stderr, "N = %d K = %d X = %d\n", N, K, X);
-    assert(!(N%2) && "N is not even");
-    assert(X > 0);
-    
-    NVM_Initialize();
-    sll_rgn_id = NVM_FindOrCreateRegion("sll_ll", O_RDWR, NULL);
-    
-    int i;
-    for (i = 1; i < N/2+1; ++i) insertPass1(i, K, X);
-    InsertAfter = SLL;
+int main(int argc, char *argv[]) {
+  struct timeval tv_start;
+  struct timeval tv_end;
+  gettimeofday(&tv_start, NULL);
 
-    for (i=N/2+1; i < N; i += X) insertPass2(i, K, X);
-    int total_inserted = i - 1;
-    insertPass2(i, K,  N - total_inserted);
+  if (argc != 4) {
+    fprintf(stderr, "usage: a.out numInts numBlanks numFAItems\n");
+    exit(0);
+  }
+  int N = atoi(argv[1]);
+  int K = atoi(argv[2]);
+  int X = atoi(argv[3]);
+  fprintf(stderr, "N = %d K = %d X = %d\n", N, K, X);
+  assert(!(N % 2) && "N is not even");
+  assert(X > 0);
 
-    fprintf(stderr, "Sum of elements is %ld\n", printSLL());
-    
-    NVM_CloseRegion(sll_rgn_id);
+  NVM_Initialize();
+  sll_rgn_id = NVM_FindOrCreateRegion("sll_ll", O_RDWR, NULL);
+
+  int i;
+  for (i = 1; i < N / 2 + 1; ++i) {
+    insertPass1(i, K, X);
+  }
+  InsertAfter = SLL;
+
+  for (i = N / 2 + 1; i < N; i += X) {
+    insertPass2(i, K, X);
+  }
+  int total_inserted = i - 1;
+  insertPass2(i, K, N - total_inserted);
+
+  fprintf(stderr, "Sum of elements is %ld\n", printSLL());
+
+  NVM_CloseRegion(sll_rgn_id);
 #ifdef NVM_STATS
-    NVM_PrintStats();
-#endif    
-    NVM_Finalize();
+  NVM_PrintStats();
+#endif
+  NVM_Finalize();
 
-    gettimeofday(&tv_end, NULL);
+  gettimeofday(&tv_end, NULL);
 
-    fprintf(stderr, "time elapsed %ld us\n",
-            tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
-    return 0;
+  fprintf(stderr, "time elapsed %ld us\n",
+          tv_end.tv_usec - tv_start.tv_usec +
+              (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+  return 0;
 }

--- a/runtime/tests/data_structures_instrumented/sll_nvm.cpp
+++ b/runtime/tests/data_structures_instrumented/sll_nvm.cpp
@@ -35,13 +35,13 @@
 #include "atlas_api.h"
 
 typedef struct Node {
-  char *Data;
-  struct Node *Next;
+    char *Data;
+    struct Node *Next;
 } Node;
 
 typedef struct SearchResult {
-  Node *Match;
-  Node *Prev;
+    Node *Match;
+    Node *Prev;
 } SearchResult;
 
 Node *SLL = NULL;
@@ -51,139 +51,141 @@ uint32_t sll_rgn_id;
 
 Node *createSingleNode(int Num, int NumBlanks) {
 #if defined(_USE_MALLOC)
-  Node *node = (Node *)malloc(sizeof(Node));
+    Node *node = (Node *)malloc(sizeof(Node));
 #else
-  Node *node = (Node *)nvm_alloc(sizeof(Node), sll_rgn_id);
+    Node *node = (Node *)nvm_alloc(sizeof(Node), sll_rgn_id);
 #endif
-  int num_digits = log10(Num) + 1;
-  int len = num_digits + NumBlanks;
+    int num_digits = log10(Num) + 1;
+    int len = num_digits + NumBlanks;
 #if defined(_USE_MALLOC)
-  char *d = (char *)malloc((len + 1) * sizeof(char));
+    char *d = (char *)malloc((len + 1) * sizeof(char));
 #else
-  char *d = (char *)nvm_alloc((len + 1) * sizeof(char), sll_rgn_id);
+    char *d = (char *)nvm_alloc((len + 1) * sizeof(char), sll_rgn_id);
 #endif
 
-  NVM_STR2(node->Data, d, sizeof(char *) * 8);
+    NVM_STR2(node->Data, d, sizeof(char *) * 8);
 
-  char *tmp_s = (char *)alloca(
-      (num_digits > NumBlanks ? num_digits + 1 : NumBlanks + 1) * sizeof(char));
-  sprintf(tmp_s, "%d", Num);
+    char *tmp_s = (char *)alloca(
+        (num_digits > NumBlanks ? num_digits + 1 : NumBlanks + 1) *
+        sizeof(char));
+    sprintf(tmp_s, "%d", Num);
 
-  NVM_MEMCPY(node->Data, tmp_s, num_digits);
+    NVM_MEMCPY(node->Data, tmp_s, num_digits);
 
-  for (int i = 0; i < NumBlanks; ++i) {
-    tmp_s[i] = ' ';
-  }
-  NVM_MEMCPY(node->Data + num_digits, tmp_s, NumBlanks);
-  NVM_STR2(node->Data[num_digits + NumBlanks], '\0', sizeof(char) * 8);
-  return node;
+    for (int i = 0; i < NumBlanks; ++i) {
+        tmp_s[i] = ' ';
+    }
+    NVM_MEMCPY(node->Data + num_digits, tmp_s, NumBlanks);
+    NVM_STR2(node->Data[num_digits + NumBlanks], '\0', sizeof(char) * 8);
+    return node;
 }
 
 Node *insertPass1(int Num, int NumBlanks, int NumFAI) {
-  Node *node = createSingleNode(Num, NumBlanks);
+    Node *node = createSingleNode(Num, NumBlanks);
 
-  // In pass 1, the new node is the last node in the list
-  NVM_STR2(node->Next, NULL, sizeof(node->Next) * 8);
+    // In pass 1, the new node is the last node in the list
+    NVM_STR2(node->Next, NULL, sizeof(node->Next) * 8);
 
-  NVM_BEGIN_DURABLE();
+    NVM_BEGIN_DURABLE();
 
-  if (!SLL) {
-    NVM_STR2(SLL, node, sizeof(SLL) * 8); // write-once
-    InsertAfter = node;
-  } else {
-    NVM_STR2(InsertAfter->Next, node, sizeof(InsertAfter->Next) * 8);
-    InsertAfter = node;
-  }
-  NVM_END_DURABLE();
+    if (!SLL) {
+        NVM_STR2(SLL, node, sizeof(SLL) * 8); // write-once
+        InsertAfter = node;
+    } else {
+        NVM_STR2(InsertAfter->Next, node, sizeof(InsertAfter->Next) * 8);
+        InsertAfter = node;
+    }
+    NVM_END_DURABLE();
 
-  return node;
+    return node;
 }
 
 Node *insertPass2(int Num, int NumBlanks, int NumFAI) {
-  Node **new_nodes = (Node **)malloc(NumFAI * sizeof(Node *));
-  Node *list_iter = InsertAfter->Next;
-  for (int i = 0; i < NumFAI; i++) {
-    new_nodes[i] = createSingleNode(Num + i, NumBlanks);
-    if (list_iter != NULL) {
-      NVM_STR2(new_nodes[i]->Next, list_iter, sizeof(list_iter) * 8);
-    } else {
-      break;
+    Node **new_nodes = (Node **)malloc(NumFAI * sizeof(Node *));
+    Node *list_iter = InsertAfter->Next;
+    for (int i = 0; i < NumFAI; i++) {
+        new_nodes[i] = createSingleNode(Num + i, NumBlanks);
+        if (list_iter != NULL) {
+            NVM_STR2(new_nodes[i]->Next, list_iter, sizeof(list_iter) * 8);
+        } else {
+            break;
+        }
+        list_iter = list_iter->Next;
     }
-    list_iter = list_iter->Next;
-  }
 
-  NVM_BEGIN_DURABLE();
+    NVM_BEGIN_DURABLE();
 
-  for (int i = 0; i < NumFAI; i++) {
-    NVM_STR2(InsertAfter->Next, new_nodes[i], sizeof(InsertAfter->Next) * 8);
-    if (new_nodes[i]->Next != NULL) {
-      InsertAfter = new_nodes[i]->Next;
-    } else {
-      InsertAfter = new_nodes[i];
-      break;
+    for (int i = 0; i < NumFAI; i++) {
+        NVM_STR2(InsertAfter->Next, new_nodes[i],
+                 sizeof(InsertAfter->Next) * 8);
+        if (new_nodes[i]->Next != NULL) {
+            InsertAfter = new_nodes[i]->Next;
+        } else {
+            InsertAfter = new_nodes[i];
+            break;
+        }
     }
-  }
 
-  NVM_END_DURABLE();
+    NVM_END_DURABLE();
 
-  return InsertAfter;
+    return InsertAfter;
 }
 
 long printSLL() {
-  long sum = 0;
-  Node *tnode = SLL;
-  while (tnode) {
-    //        fprintf(stderr, "%s ", tnode->Data);
-    sum += atoi(tnode->Data);
-    tnode = tnode->Next;
-  }
-  //    fprintf(stderr, "\n");
-  return sum;
+    long sum = 0;
+    Node *tnode = SLL;
+    while (tnode) {
+        //        fprintf(stderr, "%s ", tnode->Data);
+        sum += atoi(tnode->Data);
+        tnode = tnode->Next;
+    }
+    //    fprintf(stderr, "\n");
+    return sum;
 }
 
 int main(int argc, char *argv[]) {
-  struct timeval tv_start;
-  struct timeval tv_end;
-  gettimeofday(&tv_start, NULL);
+    struct timeval tv_start;
+    struct timeval tv_end;
+    gettimeofday(&tv_start, NULL);
 
-  if (argc != 4) {
-    fprintf(stderr, "usage: a.out numInts numBlanks numFAItems\n");
-    exit(0);
-  }
-  int N = atoi(argv[1]);
-  int K = atoi(argv[2]);
-  int X = atoi(argv[3]);
-  fprintf(stderr, "N = %d K = %d X = %d\n", N, K, X);
-  assert(!(N % 2) && "N is not even");
-  assert(X > 0);
+    if (argc != 4) {
+        fprintf(stderr, "usage: a.out numInts numBlanks numFAItems\n");
+        exit(0);
+    }
+    int N = atoi(argv[1]);
+    int K = atoi(argv[2]);
+    int X = atoi(argv[3]);
+    fprintf(stderr, "N = %d K = %d X = %d\n", N, K, X);
+    assert(!(N % 2) && "N is not even");
+    assert(X > 0);
 
-  NVM_Initialize();
-  sll_rgn_id = NVM_FindOrCreateRegion("sll_ll", O_RDWR, NULL);
+    NVM_Initialize();
+    sll_rgn_id = NVM_FindOrCreateRegion("sll_ll", O_RDWR, NULL);
 
-  int i;
-  for (i = 1; i < N / 2 + 1; ++i) {
-    insertPass1(i, K, X);
-  }
-  InsertAfter = SLL;
+    int i;
+    for (i = 1; i < N / 2 + 1; ++i) {
+        insertPass1(i, K, X);
+    }
+    InsertAfter = SLL;
 
-  for (i = N / 2 + 1; i < N; i += X) {
-    insertPass2(i, K, X);
-  }
-  int total_inserted = i - 1;
-  insertPass2(i, K, N - total_inserted);
+    for (i = N / 2 + 1; i < N; i += X) {
+        insertPass2(i, K, X);
+    }
+    int total_inserted = i - 1;
+    insertPass2(i, K, N - total_inserted);
 
-  fprintf(stderr, "Sum of elements is %ld\n", printSLL());
+    fprintf(stderr, "Sum of elements is %ld\n", printSLL());
 
-  NVM_CloseRegion(sll_rgn_id);
+    NVM_CloseRegion(sll_rgn_id);
 #ifdef NVM_STATS
-  NVM_PrintStats();
+    NVM_PrintStats();
 #endif
-  NVM_Finalize();
+    NVM_Finalize();
 
-  gettimeofday(&tv_end, NULL);
+    gettimeofday(&tv_end, NULL);
 
-  fprintf(stderr, "time elapsed %ld us\n",
-          tv_end.tv_usec - tv_start.tv_usec +
-              (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
-  return 0;
+    fprintf(stderr, "time elapsed %ld us\n",
+            tv_end.tv_usec - tv_start.tv_usec +
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+    return 0;
 }

--- a/runtime/tests/data_structures_instrumented/stores_nvm.c
+++ b/runtime/tests/data_structures_instrumented/stores_nvm.c
@@ -12,7 +12,6 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
 // This is an example of a program that has been manually instrumented
 // with Atlas internal APIs. This is just for understanding
@@ -23,13 +22,14 @@
 // little performance advantage. If you still want to instrument
 // manually, make sure you compile the manually instrumented program
 // using your favorite compiler, not the Atlas-aware compiler.
+
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <sys/time.h>
 
-#include "atlas_api.h"
 #include "atlas_alloc.h"
+#include "atlas_api.h"
 
 #define LOOP_COUNT 1000000
 
@@ -38,63 +38,60 @@ void bar();
 uint32_t stores_rgn_id;
 
 inline uint64_t rdtsc() {
-    uint32_t lo, hi;
-    asm volatile ("rdtsc" : "=a" (lo), "=d" (hi));
-    return lo | ((uint64_t)hi << 32);
+  uint32_t lo, hi;
+  asm volatile("rdtsc" : "=a"(lo), "=d"(hi));
+  return lo | ((uint64_t)hi << 32);
 }
 
 typedef int ARR_TYPE;
 
-int main(int argc, char *argv[])
-{
-    ARR_TYPE *arr;
-    int count = 0;
-    struct timeval tv_start;
-    struct timeval tv_end;
+int main(int argc, char *argv[]) {
+  ARR_TYPE *arr;
+  int count = 0;
+  struct timeval tv_start;
+  struct timeval tv_end;
 
-    NVM_Initialize();
-    stores_rgn_id = NVM_FindOrCreateRegion("stores", O_RDWR, NULL);
-    arr = (ARR_TYPE*)nvm_alloc(LOOP_COUNT*sizeof(ARR_TYPE), stores_rgn_id);
-    
-    assert(!gettimeofday(&tv_start, NULL));
+  NVM_Initialize();
+  stores_rgn_id = NVM_FindOrCreateRegion("stores", O_RDWR, NULL);
+  arr = (ARR_TYPE *)nvm_alloc(LOOP_COUNT * sizeof(ARR_TYPE), stores_rgn_id);
 
-    uint64_t start = rdtsc();
-    
-    int i;
+  assert(!gettimeofday(&tv_start, NULL));
 
-//    NVM_BEGIN_DURABLE();
-    for (i=0; i<LOOP_COUNT; i++)
-    {
-        NVM_BEGIN_DURABLE();
-        
-        NVM_STR2(arr[i], i, sizeof(arr[i])*8);
-        
-        NVM_END_DURABLE();
-    }
-//    NVM_END_DURABLE();
+  uint64_t start = rdtsc();
 
-    assert(!gettimeofday(&tv_end, NULL));
+  int i;
 
-    uint64_t end = rdtsc();
+  //    NVM_BEGIN_DURABLE();
+  for (i = 0; i < LOOP_COUNT; i++) {
+    NVM_BEGIN_DURABLE();
 
-    for (i=0; i<LOOP_COUNT; ++i)
-        count += arr[i];
+    NVM_STR2(arr[i], i, sizeof(arr[i]) * 8);
 
-    NVM_CloseRegion(stores_rgn_id);
+    NVM_END_DURABLE();
+  }
+  //    NVM_END_DURABLE();
+
+  assert(!gettimeofday(&tv_end, NULL));
+
+  uint64_t end = rdtsc();
+
+  for (i = 0; i < LOOP_COUNT; ++i) {
+    count += arr[i];
+  }
+
+  NVM_CloseRegion(stores_rgn_id);
 
 #ifdef NVM_STATS
-    NVM_PrintStats();
-#endif    
-    
-    NVM_Finalize();
-    
-    fprintf(stderr, "Sume of elements is %d\n", count);
-    fprintf(stderr, "time elapsed %ld us\n",
-            tv_end.tv_usec - tv_start.tv_usec +
-            (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
-    fprintf(stderr, "cycles: %ld\n", end - start);
-    
-    return 0;
-}
+  NVM_PrintStats();
+#endif
 
-    
+  NVM_Finalize();
+
+  fprintf(stderr, "Sume of elements is %d\n", count);
+  fprintf(stderr, "time elapsed %ld us\n",
+          tv_end.tv_usec - tv_start.tv_usec +
+              (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+  fprintf(stderr, "cycles: %ld\n", end - start);
+
+  return 0;
+}

--- a/runtime/tests/data_structures_instrumented/stores_nvm.c
+++ b/runtime/tests/data_structures_instrumented/stores_nvm.c
@@ -38,60 +38,60 @@ void bar();
 uint32_t stores_rgn_id;
 
 inline uint64_t rdtsc() {
-  uint32_t lo, hi;
-  __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
-  return lo | ((uint64_t)hi << 32);
+    uint32_t lo, hi;
+    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+    return lo | ((uint64_t)hi << 32);
 }
 
 typedef int ARR_TYPE;
 
 int main(int argc, char *argv[]) {
-  ARR_TYPE *arr;
-  int count = 0;
-  struct timeval tv_start;
-  struct timeval tv_end;
+    ARR_TYPE *arr;
+    int count = 0;
+    struct timeval tv_start;
+    struct timeval tv_end;
 
-  NVM_Initialize();
-  stores_rgn_id = NVM_FindOrCreateRegion("stores", O_RDWR, NULL);
-  arr = (ARR_TYPE *)nvm_alloc(LOOP_COUNT * sizeof(ARR_TYPE), stores_rgn_id);
+    NVM_Initialize();
+    stores_rgn_id = NVM_FindOrCreateRegion("stores", O_RDWR, NULL);
+    arr = (ARR_TYPE *)nvm_alloc(LOOP_COUNT * sizeof(ARR_TYPE), stores_rgn_id);
 
-  assert(!gettimeofday(&tv_start, NULL));
+    assert(!gettimeofday(&tv_start, NULL));
 
-  uint64_t start = rdtsc();
+    uint64_t start = rdtsc();
 
-  int i;
+    int i;
 
-  //    NVM_BEGIN_DURABLE();
-  for (i = 0; i < LOOP_COUNT; i++) {
-    NVM_BEGIN_DURABLE();
+    //    NVM_BEGIN_DURABLE();
+    for (i = 0; i < LOOP_COUNT; i++) {
+        NVM_BEGIN_DURABLE();
 
-    NVM_STR2(arr[i], i, sizeof(arr[i]) * 8);
+        NVM_STR2(arr[i], i, sizeof(arr[i]) * 8);
 
-    NVM_END_DURABLE();
-  }
-  //    NVM_END_DURABLE();
+        NVM_END_DURABLE();
+    }
+    //    NVM_END_DURABLE();
 
-  assert(!gettimeofday(&tv_end, NULL));
+    assert(!gettimeofday(&tv_end, NULL));
 
-  uint64_t end = rdtsc();
+    uint64_t end = rdtsc();
 
-  for (i = 0; i < LOOP_COUNT; ++i) {
-    count += arr[i];
-  }
+    for (i = 0; i < LOOP_COUNT; ++i) {
+        count += arr[i];
+    }
 
-  NVM_CloseRegion(stores_rgn_id);
+    NVM_CloseRegion(stores_rgn_id);
 
 #ifdef NVM_STATS
-  NVM_PrintStats();
+    NVM_PrintStats();
 #endif
 
-  NVM_Finalize();
+    NVM_Finalize();
 
-  fprintf(stderr, "Sume of elements is %d\n", count);
-  fprintf(stderr, "time elapsed %ld us\n",
-          tv_end.tv_usec - tv_start.tv_usec +
-              (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
-  fprintf(stderr, "cycles: %ld\n", end - start);
+    fprintf(stderr, "Sume of elements is %d\n", count);
+    fprintf(stderr, "time elapsed %ld us\n",
+            tv_end.tv_usec - tv_start.tv_usec +
+                (tv_end.tv_sec - tv_start.tv_sec) * 1000000);
+    fprintf(stderr, "cycles: %ld\n", end - start);
 
-  return 0;
+    return 0;
 }

--- a/runtime/tests/data_structures_instrumented/stores_nvm.c
+++ b/runtime/tests/data_structures_instrumented/stores_nvm.c
@@ -39,7 +39,7 @@ uint32_t stores_rgn_id;
 
 inline uint64_t rdtsc() {
   uint32_t lo, hi;
-  asm volatile("rdtsc" : "=a"(lo), "=d"(hi));
+  __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
   return lo | ((uint64_t)hi << 32);
 }
 

--- a/runtime/tests/data_structures_instrumented/test_memfns.c
+++ b/runtime/tests/data_structures_instrumented/test_memfns.c
@@ -12,7 +12,6 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
 // This is an example of a program that has been manually instrumented
 // with Atlas internal APIs. This is just for understanding
@@ -23,38 +22,38 @@
 // little performance advantage. If you still want to instrument
 // manually, make sure you compile the manually instrumented program
 // using your favorite compiler, not the Atlas-aware compiler.
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "atlas_api.h"
 #include "atlas_alloc.h"
+#include "atlas_api.h"
 
 #define MAXLEN 256
-    
-int main()
-{
-    NVM_Initialize();
-    uint32_t rgn_id = NVM_FindOrCreateRegion("memtest", O_RDWR, NULL);
-    
-    char * buf1 = (char *) nvm_alloc(MAXLEN, rgn_id);
-    char * buf2 = (char *) nvm_alloc(MAXLEN, rgn_id);
 
-    strcpy(buf1, "This is a test                                    \n");
+int main() {
+  NVM_Initialize();
+  uint32_t rgn_id = NVM_FindOrCreateRegion("memtest", O_RDWR, NULL);
 
-    NVM_BEGIN_DURABLE();
-    
-    NVM_MEMSET(buf1+15, ':', 1);
-    NVM_MEMCPY(buf2, buf1, MAXLEN);
-    NVM_MEMMOVE(buf2+20, buf2, MAXLEN/2);
+  char *buf1 = (char *)nvm_alloc(MAXLEN, rgn_id);
+  char *buf2 = (char *)nvm_alloc(MAXLEN, rgn_id);
 
-    NVM_END_DURABLE();
-    
-    fprintf(stderr, "buf1=%s\n", buf1);
-    fprintf(stderr, "buf2=%s\n", buf2);
+  strcpy(buf1, "This is a test                                    \n");
 
-    NVM_CloseRegion(rgn_id);
-    NVM_Finalize();
-    
-    return 0;
+  NVM_BEGIN_DURABLE();
+
+  NVM_MEMSET(buf1 + 15, ':', 1);
+  NVM_MEMCPY(buf2, buf1, MAXLEN);
+  NVM_MEMMOVE(buf2 + 20, buf2, MAXLEN / 2);
+
+  NVM_END_DURABLE();
+
+  fprintf(stderr, "buf1=%s\n", buf1);
+  fprintf(stderr, "buf2=%s\n", buf2);
+
+  NVM_CloseRegion(rgn_id);
+  NVM_Finalize();
+
+  return 0;
 }

--- a/runtime/tests/data_structures_instrumented/test_memfns.c
+++ b/runtime/tests/data_structures_instrumented/test_memfns.c
@@ -33,27 +33,27 @@
 #define MAXLEN 256
 
 int main() {
-  NVM_Initialize();
-  uint32_t rgn_id = NVM_FindOrCreateRegion("memtest", O_RDWR, NULL);
+    NVM_Initialize();
+    uint32_t rgn_id = NVM_FindOrCreateRegion("memtest", O_RDWR, NULL);
 
-  char *buf1 = (char *)nvm_alloc(MAXLEN, rgn_id);
-  char *buf2 = (char *)nvm_alloc(MAXLEN, rgn_id);
+    char *buf1 = (char *)nvm_alloc(MAXLEN, rgn_id);
+    char *buf2 = (char *)nvm_alloc(MAXLEN, rgn_id);
 
-  strcpy(buf1, "This is a test                                    \n");
+    strcpy(buf1, "This is a test                                    \n");
 
-  NVM_BEGIN_DURABLE();
+    NVM_BEGIN_DURABLE();
 
-  NVM_MEMSET(buf1 + 15, ':', 1);
-  NVM_MEMCPY(buf2, buf1, MAXLEN);
-  NVM_MEMMOVE(buf2 + 20, buf2, MAXLEN / 2);
+    NVM_MEMSET(buf1 + 15, ':', 1);
+    NVM_MEMCPY(buf2, buf1, MAXLEN);
+    NVM_MEMMOVE(buf2 + 20, buf2, MAXLEN / 2);
 
-  NVM_END_DURABLE();
+    NVM_END_DURABLE();
 
-  fprintf(stderr, "buf1=%s\n", buf1);
-  fprintf(stderr, "buf2=%s\n", buf2);
+    fprintf(stderr, "buf1=%s\n", buf1);
+    fprintf(stderr, "buf2=%s\n", buf2);
 
-  NVM_CloseRegion(rgn_id);
-  NVM_Finalize();
+    NVM_CloseRegion(rgn_id);
+    NVM_Finalize();
 
-  return 0;
+    return 0;
 }

--- a/runtime/tests/region/README.md
+++ b/runtime/tests/region/README.md
@@ -17,8 +17,8 @@
 
 ## Usage
 
-To run the test script do `./test_region_instr false`. Run with
-`./test_region_instr true` to see debug information, if there are errors
+To run the test script do `./test_region false`. Run with
+`./test_region true` to see debug information, if there are errors
 for example.
 
 ## Test Structure
@@ -34,7 +34,7 @@ The order in which the Atlas region api is called is in the filename, e.g.:
  `CloseRegion`
 - `finddelete.c`: `FindRegion`, `DeleteRegion`
 
-The test script `test_region_instr`, runs these tests up to 100 times
+The test script `test_region`, runs these tests up to 100 times
 depending on expected behaviour.  There are three behaviours in two
 classes:
 
@@ -45,7 +45,7 @@ The test programs are put into one of the two classes depending on if
 they should run in the first place.  If they are runnable the programs
 either execute one of the three behaviours when run again.
 
-To add a test, edit `CMakeLists.txt`, and in `test_region_instr` add the
+To add a test, edit `CMakeLists.txt`, and in `test_region` add the
 test name to the respective local arrays in function `run_tests`.  E.g.
 creating a test `focdelete` which is runnable and creates regions must be
 added to `runnable_tests` and `tests_create`. A test `finddelete` which is

--- a/runtime/tests/region/createclose.c
+++ b/runtime/tests/region/createclose.c
@@ -12,20 +12,20 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
-#include <stdio.h>
-#include <assert.h>
 #include "region_test.h"
+#include <assert.h>
+#include <stdio.h>
 
 uint32_t rgn_id;
 
-int main(){
-    //WORK and ITERATIONS are macros defined in compilation
-    NVM_Initialize();
-    rgn_id = NVM_CreateRegion("createclose", O_RDWR);
-    test(rgn_id);
-    NVM_CloseRegion(rgn_id);
-    NVM_Finalize();
-    return 0;
+int main() {
+  // WORK and ITERATIONS are macros defined in compilation
+  NVM_Initialize();
+  rgn_id = NVM_CreateRegion("createclose", O_RDWR);
+  test(rgn_id);
+  NVM_CloseRegion(rgn_id);
+  NVM_Finalize();
+
+  return 0;
 }

--- a/runtime/tests/region/createclose.c
+++ b/runtime/tests/region/createclose.c
@@ -20,12 +20,12 @@
 uint32_t rgn_id;
 
 int main() {
-  // WORK and ITERATIONS are macros defined in compilation
-  NVM_Initialize();
-  rgn_id = NVM_CreateRegion("createclose", O_RDWR);
-  test(rgn_id);
-  NVM_CloseRegion(rgn_id);
-  NVM_Finalize();
+    // WORK and ITERATIONS are macros defined in compilation
+    NVM_Initialize();
+    rgn_id = NVM_CreateRegion("createclose", O_RDWR);
+    test(rgn_id);
+    NVM_CloseRegion(rgn_id);
+    NVM_Finalize();
 
-  return 0;
+    return 0;
 }

--- a/runtime/tests/region/createclosedelete.c
+++ b/runtime/tests/region/createclosedelete.c
@@ -12,23 +12,26 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
-#include <stdio.h>
-#include <assert.h>
 #include "region_test.h"
+#include <assert.h>
+#include <stdio.h>
 
 uint32_t rgn_id;
 
-int main(){
-    //WORK and ITERATIONS are macros defined in compilation
-    NVM_Initialize();
-    rgn_id = NVM_CreateRegion("createclosedelete", O_RDWR);
-    test(rgn_id);
-    NVM_CloseRegion(rgn_id);
-    rgn_id = NVM_FindRegion("createclosedelete", O_RDWR);
-    test(rgn_id);
-    NVM_DeleteRegion("createclosedelete");
-    NVM_Finalize();
-    return 0;
+int main() {
+  // WORK and ITERATIONS are macros defined in compilation
+  NVM_Initialize();
+
+  rgn_id = NVM_CreateRegion("createclosedelete", O_RDWR);
+  test(rgn_id);
+  NVM_CloseRegion(rgn_id);
+
+  rgn_id = NVM_FindRegion("createclosedelete", O_RDWR);
+  test(rgn_id);
+  NVM_DeleteRegion("createclosedelete");
+
+  NVM_Finalize();
+
+  return 0;
 }

--- a/runtime/tests/region/createclosedelete.c
+++ b/runtime/tests/region/createclosedelete.c
@@ -20,18 +20,18 @@
 uint32_t rgn_id;
 
 int main() {
-  // WORK and ITERATIONS are macros defined in compilation
-  NVM_Initialize();
+    // WORK and ITERATIONS are macros defined in compilation
+    NVM_Initialize();
 
-  rgn_id = NVM_CreateRegion("createclosedelete", O_RDWR);
-  test(rgn_id);
-  NVM_CloseRegion(rgn_id);
+    rgn_id = NVM_CreateRegion("createclosedelete", O_RDWR);
+    test(rgn_id);
+    NVM_CloseRegion(rgn_id);
 
-  rgn_id = NVM_FindRegion("createclosedelete", O_RDWR);
-  test(rgn_id);
-  NVM_DeleteRegion("createclosedelete");
+    rgn_id = NVM_FindRegion("createclosedelete", O_RDWR);
+    test(rgn_id);
+    NVM_DeleteRegion("createclosedelete");
 
-  NVM_Finalize();
+    NVM_Finalize();
 
-  return 0;
+    return 0;
 }

--- a/runtime/tests/region/createclosefocclose.c
+++ b/runtime/tests/region/createclosefocclose.c
@@ -20,18 +20,18 @@
 uint32_t rgn_id;
 
 int main() {
-  // WORK and ITERATIONS are macros defined in compilation
-  NVM_Initialize();
+    // WORK and ITERATIONS are macros defined in compilation
+    NVM_Initialize();
 
-  rgn_id = NVM_CreateRegion("createclosefindclose", O_RDWR);
-  test(rgn_id);
-  NVM_CloseRegion(rgn_id);
+    rgn_id = NVM_CreateRegion("createclosefindclose", O_RDWR);
+    test(rgn_id);
+    NVM_CloseRegion(rgn_id);
 
-  rgn_id = NVM_FindRegion("createclosefindclose", O_RDWR);
-  test(rgn_id);
-  NVM_CloseRegion(rgn_id);
+    rgn_id = NVM_FindRegion("createclosefindclose", O_RDWR);
+    test(rgn_id);
+    NVM_CloseRegion(rgn_id);
 
-  NVM_Finalize();
+    NVM_Finalize();
 
-  return 0;
+    return 0;
 }

--- a/runtime/tests/region/createclosefocclose.c
+++ b/runtime/tests/region/createclosefocclose.c
@@ -12,23 +12,26 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
-#include <stdio.h>
-#include <assert.h>
 #include "region_test.h"
+#include <assert.h>
+#include <stdio.h>
 
 uint32_t rgn_id;
 
-int main(){
-    //WORK and ITERATIONS are macros defined in compilation
-    NVM_Initialize();
-    rgn_id = NVM_CreateRegion("createclosefindclose", O_RDWR);
-    test(rgn_id);
-    NVM_CloseRegion(rgn_id);
-    rgn_id = NVM_FindRegion("createclosefindclose", O_RDWR);
-    test(rgn_id);
-    NVM_CloseRegion(rgn_id);
-    NVM_Finalize();
-    return 0;
+int main() {
+  // WORK and ITERATIONS are macros defined in compilation
+  NVM_Initialize();
+
+  rgn_id = NVM_CreateRegion("createclosefindclose", O_RDWR);
+  test(rgn_id);
+  NVM_CloseRegion(rgn_id);
+
+  rgn_id = NVM_FindRegion("createclosefindclose", O_RDWR);
+  test(rgn_id);
+  NVM_CloseRegion(rgn_id);
+
+  NVM_Finalize();
+
+  return 0;
 }

--- a/runtime/tests/region/finddelete.c
+++ b/runtime/tests/region/finddelete.c
@@ -19,12 +19,12 @@
 uint32_t rgn_id;
 
 int main() {
-  // WORK and ITERATIONS are macros defined in compilation
-  NVM_Initialize();
-  rgn_id = NVM_FindRegion("finddelete", O_RDWR);
-  test(rgn_id);
-  NVM_DeleteRegion("finddelete");
-  NVM_Finalize();
+    // WORK and ITERATIONS are macros defined in compilation
+    NVM_Initialize();
+    rgn_id = NVM_FindRegion("finddelete", O_RDWR);
+    test(rgn_id);
+    NVM_DeleteRegion("finddelete");
+    NVM_Finalize();
 
-  return 0;
+    return 0;
 }

--- a/runtime/tests/region/finddelete.c
+++ b/runtime/tests/region/finddelete.c
@@ -12,19 +12,19 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
-#include <stdio.h>
 #include "region_test.h"
+#include <stdio.h>
 
 uint32_t rgn_id;
 
-int main(){
-    //WORK and ITERATIONS are macros defined in compilation
-    NVM_Initialize();
-    rgn_id = NVM_FindRegion("finddelete", O_RDWR);
-    test(rgn_id);
-    NVM_DeleteRegion("finddelete");
-    NVM_Finalize();
-    return 0; 
+int main() {
+  // WORK and ITERATIONS are macros defined in compilation
+  NVM_Initialize();
+  rgn_id = NVM_FindRegion("finddelete", O_RDWR);
+  test(rgn_id);
+  NVM_DeleteRegion("finddelete");
+  NVM_Finalize();
+
+  return 0;
 }

--- a/runtime/tests/region/focclose.c
+++ b/runtime/tests/region/focclose.c
@@ -12,19 +12,19 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
-#include <stdio.h>
 #include "region_test.h"
+#include <stdio.h>
 
 uint32_t rgn_id;
 
-int main(){
-    //WORK and ITERATIONS are macros defined in compilation
-    NVM_Initialize();
-    rgn_id = NVM_FindOrCreateRegion("findclose", O_RDWR, NULL);
-    test(rgn_id);
-    NVM_CloseRegion(rgn_id);
-    NVM_Finalize();
-    return 0; 
+int main() {
+  // WORK and ITERATIONS are macros defined in compilation
+  NVM_Initialize();
+  rgn_id = NVM_FindOrCreateRegion("findclose", O_RDWR, NULL);
+  test(rgn_id);
+  NVM_CloseRegion(rgn_id);
+  NVM_Finalize();
+
+  return 0;
 }

--- a/runtime/tests/region/focclose.c
+++ b/runtime/tests/region/focclose.c
@@ -19,12 +19,12 @@
 uint32_t rgn_id;
 
 int main() {
-  // WORK and ITERATIONS are macros defined in compilation
-  NVM_Initialize();
-  rgn_id = NVM_FindOrCreateRegion("findclose", O_RDWR, NULL);
-  test(rgn_id);
-  NVM_CloseRegion(rgn_id);
-  NVM_Finalize();
+    // WORK and ITERATIONS are macros defined in compilation
+    NVM_Initialize();
+    rgn_id = NVM_FindOrCreateRegion("findclose", O_RDWR, NULL);
+    test(rgn_id);
+    NVM_CloseRegion(rgn_id);
+    NVM_Finalize();
 
-  return 0;
+    return 0;
 }

--- a/runtime/tests/region/focdelete.c
+++ b/runtime/tests/region/focdelete.c
@@ -20,12 +20,12 @@
 uint32_t rgn_id;
 
 int main() {
-  // WORK and ITERATIONS are macros defined in compilation
-  NVM_Initialize();
-  rgn_id = NVM_FindOrCreateRegion("finddelete", O_RDWR, NULL);
-  test(rgn_id);
-  NVM_DeleteRegion("finddelete");
-  NVM_Finalize();
+    // WORK and ITERATIONS are macros defined in compilation
+    NVM_Initialize();
+    rgn_id = NVM_FindOrCreateRegion("finddelete", O_RDWR, NULL);
+    test(rgn_id);
+    NVM_DeleteRegion("finddelete");
+    NVM_Finalize();
 
-  return 0;
+    return 0;
 }

--- a/runtime/tests/region/focdelete.c
+++ b/runtime/tests/region/focdelete.c
@@ -12,20 +12,20 @@
  * General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
 
-#include <stdio.h>
-#include <assert.h>
 #include "region_test.h"
+#include <assert.h>
+#include <stdio.h>
 
 uint32_t rgn_id;
 
-int main(){
-    //WORK and ITERATIONS are macros defined in compilation
-    NVM_Initialize();
-    rgn_id = NVM_FindOrCreateRegion("finddelete", O_RDWR, NULL);
-    test(rgn_id);
-    NVM_DeleteRegion("finddelete");
-    NVM_Finalize();
-    return 0; 
+int main() {
+  // WORK and ITERATIONS are macros defined in compilation
+  NVM_Initialize();
+  rgn_id = NVM_FindOrCreateRegion("finddelete", O_RDWR, NULL);
+  test(rgn_id);
+  NVM_DeleteRegion("finddelete");
+  NVM_Finalize();
+
+  return 0;
 }

--- a/runtime/tests/region/region_test.h
+++ b/runtime/tests/region/region_test.h
@@ -29,8 +29,8 @@
 typedef struct node node;
 
 struct node {
-  node *next;
-  int work;
+    node *next;
+    int work;
 };
 
 node *root;
@@ -39,83 +39,83 @@ int num_nodes;
 uint32_t global_rgn_id;
 
 void *add() {
-  node *current;
-  int i;
-
-  pthread_mutex_lock(&root_lock);
-  if (num_nodes >= NUM_NODES) {
-    pthread_mutex_unlock(&root_lock);
-    return 0;
-  }
-  i = num_nodes;
-  pthread_mutex_unlock(&root_lock);
-
-  while (i < NUM_NODES) {
-    current = (node *)nvm_alloc(sizeof(node), global_rgn_id);
-    current->work = (i * WORK) ^ i;
+    node *current;
+    int i;
 
     pthread_mutex_lock(&root_lock);
     if (num_nodes >= NUM_NODES) {
-      nvm_free(current);
-      pthread_mutex_unlock(&root_lock);
-      break;
+        pthread_mutex_unlock(&root_lock);
+        return 0;
     }
-    i = ++num_nodes;
-    printf("Adding node number %i\n", i);
-    root->next = current;
-    root = current;
+    i = num_nodes;
     pthread_mutex_unlock(&root_lock);
-  }
-  return 0;
+
+    while (i < NUM_NODES) {
+        current = (node *)nvm_alloc(sizeof(node), global_rgn_id);
+        current->work = (i * WORK) ^ i;
+
+        pthread_mutex_lock(&root_lock);
+        if (num_nodes >= NUM_NODES) {
+            nvm_free(current);
+            pthread_mutex_unlock(&root_lock);
+            break;
+        }
+        i = ++num_nodes;
+        printf("Adding node number %i\n", i);
+        root->next = current;
+        root = current;
+        pthread_mutex_unlock(&root_lock);
+    }
+    return 0;
 }
 
 void dump() {
-  while (root != NULL) {
-    printf("Data is %i\n", root->work);
-    root = root->next;
-  }
+    while (root != NULL) {
+        printf("Data is %i\n", root->work);
+        root = root->next;
+    }
 }
 
 void test(uint32_t rgn_id) {
-  int i;
-  pthread_attr_t attr;
-  pthread_t *tid;
-  global_rgn_id = rgn_id;
+    int i;
+    pthread_attr_t attr;
+    pthread_t *tid;
+    global_rgn_id = rgn_id;
 
-  root = (node *)NVM_GetRegionRoot(rgn_id);
+    root = (node *)NVM_GetRegionRoot(rgn_id);
 
-  if (!root) {
-    root = (node *)nvm_alloc(sizeof(node), rgn_id);
-    root->next = NULL;
-    root->work = WORK;
-    num_nodes = 1;
-    NVM_SetRegionRoot(rgn_id, root);
-  }
-
-  if (root->next == NULL) {
-    assert(root && "Region root is NULL");
-
-    pthread_mutex_init(&root_lock, NULL);
-    tid = (pthread_t *)malloc(THREADS * sizeof(pthread_t));
-    pthread_attr_init(&attr);
-    pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
-
-    for (i = 0; i < THREADS; i++) {
-      printf("Creating thead %i\n", i);
-      pthread_create(&tid[i], &attr, (void *(*)(void *))add, NULL);
-      // pthread_create(&tid[i], &attr, *operation, NULL);
+    if (!root) {
+        root = (node *)nvm_alloc(sizeof(node), rgn_id);
+        root->next = NULL;
+        root->work = WORK;
+        num_nodes = 1;
+        NVM_SetRegionRoot(rgn_id, root);
     }
 
-    printf("Waiting for threads");
+    if (root->next == NULL) {
+        assert(root && "Region root is NULL");
 
-    for (i = 0; i < THREADS; i++) {
-      pthread_join(tid[i], NULL);
+        pthread_mutex_init(&root_lock, NULL);
+        tid = (pthread_t *)malloc(THREADS * sizeof(pthread_t));
+        pthread_attr_init(&attr);
+        pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
+
+        for (i = 0; i < THREADS; i++) {
+            printf("Creating thead %i\n", i);
+            pthread_create(&tid[i], &attr, (void *(*)(void *))add, NULL);
+            // pthread_create(&tid[i], &attr, *operation, NULL);
+        }
+
+        printf("Waiting for threads");
+
+        for (i = 0; i < THREADS; i++) {
+            pthread_join(tid[i], NULL);
+        }
+
+        free(tid);
+    } else {
+        dump();
     }
 
-    free(tid);
-  } else {
-    dump();
-  }
-
-  sleep(2);
+    sleep(2);
 }

--- a/runtime/tests/region/region_test.h
+++ b/runtime/tests/region/region_test.h
@@ -38,7 +38,7 @@ pthread_mutex_t root_lock;
 int num_nodes;
 uint32_t global_rgn_id;
 
-void *add(void *unused) {
+void *add() {
   node *current;
   int i;
 
@@ -102,7 +102,7 @@ void test(uint32_t rgn_id) {
 
     for (i = 0; i < THREADS; i++) {
       printf("Creating thead %i\n", i);
-      pthread_create(&tid[i], &attr, add, NULL);
+      pthread_create(&tid[i], &attr, (void *(*)(void *))add, NULL);
       // pthread_create(&tid[i], &attr, *operation, NULL);
     }
 


### PR DESCRIPTION
Used the following scripts to cleanup code (only in the `tests` directory):
- Cleanup scripts (clang-tidy and clang-format
  - https://gist.github.com/k4rtik/c8e1daa0bcf47b5bcd64a6803fed5b74
  - https://gist.github.com/k4rtik/a0429b31f89c50a98fc2382a3b4340d9
  - https://gist.github.com/k4rtik/a4019186ac5e54852449e245a206960a
- [include-what-you-use](http://include-what-you-use.org/) (`iwyu`), for cleaning up unused headers
