### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,3 @@
-[//]: # ( (c) Copyright 2016 Hewlett Packard Enterprise Development LP         )
-[//]: # (                                                                      )
-[//]: # ( This program is free software: you can redistribute it and/or modify )
-[//]: # ( it under the terms of the GNU Lesser General Public License as       )
-[//]: # ( published by the Free Software Foundation, either version 3 of the   )
-[//]: # ( License, or (at your option) any later version. This program is      )
-[//]: # ( distributed in the hope that it will be useful, but WITHOUT ANY      )
-[//]: # ( WARRANTY; without even the implied warranty of MERCHANTABILITY or    )
-[//]: # ( FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License )
-[//]: # ( for more details. You should have received a copy of the GNU Lesser  )
-[//]: # ( General Public License along with this program. If not, see          )
-[//]: # ( <http://www.gnu.org/licenses/>.                                      )
-
-
 # Atlas: Programming for Persistent Memory
 [![Build Status](https://travis-ci.org/HewlettPackard/Atlas.svg?branch=master)](https://travis-ci.org/HewlettPackard/Atlas)
 


### PR DESCRIPTION
Although the copyright notice in the README file is written as a comment, github seems to have trouble properly parsing it, so the notice appears as broken text when the readme is rendered in the main front page. 

Suggesting to remove the unnecessary copyright notice from README. 